### PR TITLE
Update to .NET Core 1.0 RTM

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "projects": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.0-preview1-002702"
+    "version": "1.0.0-preview2-003121"
   }
 }

--- a/src/Build/project.json
+++ b/src/Build/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002702"
+      "version": "1.0.0"
     }
   },
 

--- a/src/Parsley.Tests/project.json
+++ b/src/Parsley.Tests/project.json
@@ -2,22 +2,22 @@
   "testRunner": "xunit",
   "dependencies": {
     "Parsley": { "target": "project" },
-    "Shouldly": "2.7.0",
-    "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-build10025"
+    "Shouldly": "2.8.0",
+    "xunit": "2.2.0-beta2-build3300",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
 
   "frameworks": {
     "net452": {
       "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027"
+        "Microsoft.NETCore.Platforms": "1.0.1"
       }
     },
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002702"
+          "version": "1.0.0"
         }
       },
       "imports": [

--- a/src/Parsley/project.json
+++ b/src/Parsley/project.json
@@ -18,10 +18,10 @@
     "net452": { },
     "netstandard1.1": {
       "dependencies": {
-        "System.Linq": "4.1.0-rc2-24027",
-        "System.Reflection.Extensions": "4.0.1-rc2-24027",
-        "System.Runtime.Extensions": "4.1.0-rc2-24027",
-        "System.Text.RegularExpressions": "4.0.12-rc2-24027",
+        "System.Linq": "4.1.0",
+        "System.Reflection.Extensions": "4.0.1",
+        "System.Runtime.Extensions": "4.1.0",
+        "System.Text.RegularExpressions": "4.0.12",
       }
     }
   }

--- a/src/Parsley/project.json
+++ b/src/Parsley/project.json
@@ -21,7 +21,7 @@
         "System.Linq": "4.1.0",
         "System.Reflection.Extensions": "4.0.1",
         "System.Runtime.Extensions": "4.1.0",
-        "System.Text.RegularExpressions": "4.0.12",
+        "System.Text.RegularExpressions": "4.1.0"
       }
     }
   }


### PR DESCRIPTION
Hi,

I thought I could help with the [associated item on fixie](https://github.com/fixie/fixie/issues/145).

It could be normal, but I found out thay having `net452` listed as a framework prevents the xUnit `dotnet test` runner to communicate with VS, hence no tests show up in the Test Explorer.
Updating Shoudly to `2.8.0` which is .NET Core-compatible and removing `net452` fixes this.