### PR TITLE
Reduce traversal allocations

### DIFF
--- a/src/Parsley.Tests/ErrorTests.cs
+++ b/src/Parsley.Tests/ErrorTests.cs
@@ -13,8 +13,8 @@ class ErrorTests
 
     public void CanIndicateErrorsAtTheCurrentPosition()
     {
-        new Error<object>(endOfInput.Position, endOfInput.EndOfInput, ErrorMessage.Unknown()).ErrorMessages.ToString().ShouldBe("Parse error.");
-        new Error<object>(endOfInput.Position, endOfInput.EndOfInput, ErrorMessage.Expected("statement")).ErrorMessages.ToString().ShouldBe("statement expected");
+        new Error<object>(endOfInput.Position, ErrorMessage.Unknown()).ErrorMessages.ToString().ShouldBe("Parse error.");
+        new Error<object>(endOfInput.Position, ErrorMessage.Expected("statement")).ErrorMessages.ToString().ShouldBe("statement expected");
     }
 
     public void CanIndicateMultipleErrorsAtTheCurrentPosition()
@@ -23,12 +23,12 @@ class ErrorTests
             .With(ErrorMessage.Expected("A"))
             .With(ErrorMessage.Expected("B"));
 
-        new Error<object>(endOfInput.Position, endOfInput.EndOfInput, errors).ErrorMessages.ToString().ShouldBe("A or B expected");
+        new Error<object>(endOfInput.Position, errors).ErrorMessages.ToString().ShouldBe("A or B expected");
     }
 
     public void ThrowsWhenAttemptingToGetParsedValue()
     {
-        var inspectParsedValue = () => new Error<object>(x.Position, x.EndOfInput, ErrorMessage.Unknown()).Value;
+        var inspectParsedValue = () => new Error<object>(x.Position, ErrorMessage.Unknown()).Value;
         inspectParsedValue
             .ShouldThrow<MemberAccessException>()
             .Message.ShouldBe("(1, 1): Parse error.");
@@ -36,17 +36,15 @@ class ErrorTests
 
     public void HasRemainingUnparsedInput()
     {
-        var xError = new Error<object>(x.Position, x.EndOfInput, ErrorMessage.Unknown());
+        var xError = new Error<object>(x.Position, ErrorMessage.Unknown());
         xError.Position.ShouldBe(x.Position);
-        xError.EndOfInput.ShouldBe(x.EndOfInput);
 
-        var endError = new Error<object>(endOfInput.Position, endOfInput.EndOfInput, ErrorMessage.Unknown());
+        var endError = new Error<object>(endOfInput.Position, ErrorMessage.Unknown());
         endError.Position.ShouldBe(endOfInput.Position);
-        endError.EndOfInput.ShouldBe(endOfInput.EndOfInput);
     }
 
     public void ReportsErrorState()
     {
-        new Error<object>(x.Position, x.EndOfInput, ErrorMessage.Unknown()).Success.ShouldBeFalse();
+        new Error<object>(x.Position, ErrorMessage.Unknown()).Success.ShouldBeFalse();
     }
 }

--- a/src/Parsley.Tests/ErrorTests.cs
+++ b/src/Parsley.Tests/ErrorTests.cs
@@ -13,8 +13,8 @@ class ErrorTests
 
     public void CanIndicateErrorsAtTheCurrentPosition()
     {
-        new Error<object>(endOfInput, endOfInput.Position, endOfInput.EndOfInput, ErrorMessage.Unknown()).ErrorMessages.ToString().ShouldBe("Parse error.");
-        new Error<object>(endOfInput, endOfInput.Position, endOfInput.EndOfInput, ErrorMessage.Expected("statement")).ErrorMessages.ToString().ShouldBe("statement expected");
+        new Error<object>(endOfInput.Position, endOfInput.EndOfInput, ErrorMessage.Unknown()).ErrorMessages.ToString().ShouldBe("Parse error.");
+        new Error<object>(endOfInput.Position, endOfInput.EndOfInput, ErrorMessage.Expected("statement")).ErrorMessages.ToString().ShouldBe("statement expected");
     }
 
     public void CanIndicateMultipleErrorsAtTheCurrentPosition()
@@ -23,12 +23,12 @@ class ErrorTests
             .With(ErrorMessage.Expected("A"))
             .With(ErrorMessage.Expected("B"));
 
-        new Error<object>(endOfInput, endOfInput.Position, endOfInput.EndOfInput, errors).ErrorMessages.ToString().ShouldBe("A or B expected");
+        new Error<object>(endOfInput.Position, endOfInput.EndOfInput, errors).ErrorMessages.ToString().ShouldBe("A or B expected");
     }
 
     public void ThrowsWhenAttemptingToGetParsedValue()
     {
-        var inspectParsedValue = () => new Error<object>(x, x.Position, x.EndOfInput, ErrorMessage.Unknown()).Value;
+        var inspectParsedValue = () => new Error<object>(x.Position, x.EndOfInput, ErrorMessage.Unknown()).Value;
         inspectParsedValue
             .ShouldThrow<MemberAccessException>()
             .Message.ShouldBe("(1, 1): Parse error.");
@@ -36,17 +36,17 @@ class ErrorTests
 
     public void HasRemainingUnparsedInput()
     {
-        var xError = new Error<object>(x, x.Position, x.EndOfInput, ErrorMessage.Unknown());
+        var xError = new Error<object>(x.Position, x.EndOfInput, ErrorMessage.Unknown());
         xError.Position.ShouldBe(x.Position);
         xError.EndOfInput.ShouldBe(x.EndOfInput);
 
-        var endError = new Error<object>(endOfInput, endOfInput.Position, endOfInput.EndOfInput, ErrorMessage.Unknown());
+        var endError = new Error<object>(endOfInput.Position, endOfInput.EndOfInput, ErrorMessage.Unknown());
         endError.Position.ShouldBe(endOfInput.Position);
         endError.EndOfInput.ShouldBe(endOfInput.EndOfInput);
     }
 
     public void ReportsErrorState()
     {
-        new Error<object>(x, x.Position, x.EndOfInput, ErrorMessage.Unknown()).Success.ShouldBeFalse();
+        new Error<object>(x.Position, x.EndOfInput, ErrorMessage.Unknown()).Success.ShouldBeFalse();
     }
 }

--- a/src/Parsley.Tests/ErrorTests.cs
+++ b/src/Parsley.Tests/ErrorTests.cs
@@ -36,8 +36,13 @@ class ErrorTests
 
     public void HasRemainingUnparsedInput()
     {
-        new Error<object>(x, x.Position, x.EndOfInput, ErrorMessage.Unknown()).UnparsedInput.ShouldBe(x);
-        new Error<object>(endOfInput, endOfInput.Position, endOfInput.EndOfInput, ErrorMessage.Unknown()).UnparsedInput.ShouldBe(endOfInput);
+        var xError = new Error<object>(x, x.Position, x.EndOfInput, ErrorMessage.Unknown());
+        xError.Position.ShouldBe(x.Position);
+        xError.EndOfInput.ShouldBe(x.EndOfInput);
+
+        var endError = new Error<object>(endOfInput, endOfInput.Position, endOfInput.EndOfInput, ErrorMessage.Unknown());
+        endError.Position.ShouldBe(endOfInput.Position);
+        endError.EndOfInput.ShouldBe(endOfInput.EndOfInput);
     }
 
     public void ReportsErrorState()

--- a/src/Parsley.Tests/ErrorTests.cs
+++ b/src/Parsley.Tests/ErrorTests.cs
@@ -13,8 +13,8 @@ class ErrorTests
 
     public void CanIndicateErrorsAtTheCurrentPosition()
     {
-        new Error<object>(endOfInput, ErrorMessage.Unknown()).ErrorMessages.ToString().ShouldBe("Parse error.");
-        new Error<object>(endOfInput, ErrorMessage.Expected("statement")).ErrorMessages.ToString().ShouldBe("statement expected");
+        new Error<object>(endOfInput, endOfInput.Position, endOfInput.EndOfInput, ErrorMessage.Unknown()).ErrorMessages.ToString().ShouldBe("Parse error.");
+        new Error<object>(endOfInput, endOfInput.Position, endOfInput.EndOfInput, ErrorMessage.Expected("statement")).ErrorMessages.ToString().ShouldBe("statement expected");
     }
 
     public void CanIndicateMultipleErrorsAtTheCurrentPosition()
@@ -23,12 +23,12 @@ class ErrorTests
             .With(ErrorMessage.Expected("A"))
             .With(ErrorMessage.Expected("B"));
 
-        new Error<object>(endOfInput, errors).ErrorMessages.ToString().ShouldBe("A or B expected");
+        new Error<object>(endOfInput, endOfInput.Position, endOfInput.EndOfInput, errors).ErrorMessages.ToString().ShouldBe("A or B expected");
     }
 
     public void ThrowsWhenAttemptingToGetParsedValue()
     {
-        var inspectParsedValue = () => new Error<object>(x, ErrorMessage.Unknown()).Value;
+        var inspectParsedValue = () => new Error<object>(x, x.Position, x.EndOfInput, ErrorMessage.Unknown()).Value;
         inspectParsedValue
             .ShouldThrow<MemberAccessException>()
             .Message.ShouldBe("(1, 1): Parse error.");
@@ -36,12 +36,12 @@ class ErrorTests
 
     public void HasRemainingUnparsedInput()
     {
-        new Error<object>(x, ErrorMessage.Unknown()).UnparsedInput.ShouldBe(x);
-        new Error<object>(endOfInput, ErrorMessage.Unknown()).UnparsedInput.ShouldBe(endOfInput);
+        new Error<object>(x, x.Position, x.EndOfInput, ErrorMessage.Unknown()).UnparsedInput.ShouldBe(x);
+        new Error<object>(endOfInput, endOfInput.Position, endOfInput.EndOfInput, ErrorMessage.Unknown()).UnparsedInput.ShouldBe(endOfInput);
     }
 
     public void ReportsErrorState()
     {
-        new Error<object>(x, ErrorMessage.Unknown()).Success.ShouldBeFalse();
+        new Error<object>(x, x.Position, x.EndOfInput, ErrorMessage.Unknown()).Success.ShouldBeFalse();
     }
 }

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -67,7 +67,7 @@ class GrammarTests
         parser.FailsToParse("ABABA!", "!")
             .WithMessage("(1, 6): B expected");
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input);
+        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input, input.Position, input.EndOfInput);
         Action infiniteLoop = () => ZeroOrMore(succeedWithoutConsuming)(new Text(""));
 
         infiniteLoop
@@ -90,7 +90,7 @@ class GrammarTests
         parser.FailsToParse("ABABA!", "!")
             .WithMessage("(1, 6): B expected");
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input);
+        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input, input.Position, input.EndOfInput);
         Action infiniteLoop = () => OneOrMore(succeedWithoutConsuming)(new Text(""));
 
         infiniteLoop
@@ -307,7 +307,7 @@ public class AlternationTests
         //consuming input.  These tests simply describe the behavior under that
         //unusual situation.
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input);
+        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input, input.Position, input.EndOfInput);
 
         var reply = Choice(A, succeedWithoutConsuming).Parses("");
         reply.ErrorMessages.ToString().ShouldBe("A expected");

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -79,7 +79,8 @@ class GrammarTests
     {
         var parser = OneOrMore(AB);
 
-        parser.FailsToParse("").AtEndOfInput().WithMessage("(1, 1): A expected");
+        parser.FailsToParse("")
+            .WithMessage("(1, 1): A expected");
 
         parser.PartiallyParses("AB!", "!")
             .WithValue(Literals("AB"));
@@ -106,20 +107,20 @@ class GrammarTests
         parser.Parses("AB").WithValue(Literals("AB"));
         parser.Parses("AB,AB").WithValue(Literals("AB", "AB"));
         parser.Parses("AB,AB,AB").WithValue(Literals("AB", "AB", "AB"));
-        parser.FailsToParse("AB,").AtEndOfInput().WithMessage("(1, 4): A expected");
-        parser.FailsToParse("AB,A").AtEndOfInput().WithMessage("(1, 5): B expected");
+        parser.FailsToParse("AB,").WithMessage("(1, 4): A expected");
+        parser.FailsToParse("AB,A").WithMessage("(1, 5): B expected");
     }
 
     public void ApplyingARuleOneOrMoreTimesInterspersedByASeparatorRule()
     {
         var parser = OneOrMore(AB, COMMA);
 
-        parser.FailsToParse("").AtEndOfInput().WithMessage("(1, 1): A expected");
+        parser.FailsToParse("").WithMessage("(1, 1): A expected");
         parser.Parses("AB").WithValue(Literals("AB"));
         parser.Parses("AB,AB").WithValue(Literals("AB", "AB"));
         parser.Parses("AB,AB,AB").WithValue(Literals("AB", "AB", "AB"));
-        parser.FailsToParse("AB,").AtEndOfInput().WithMessage("(1, 4): A expected");
-        parser.FailsToParse("AB,A").AtEndOfInput().WithMessage("(1, 5): B expected");
+        parser.FailsToParse("AB,").WithMessage("(1, 4): A expected");
+        parser.FailsToParse("AB,A").WithMessage("(1, 5): B expected");
     }
 
     public void ParsingAnOptionalRuleZeroOrOneTimes()
@@ -291,14 +292,14 @@ public class AlternationTests
             from b in B
             select a + b;
 
-        Choice(AB, NeverExecuted).FailsToParse("A").AtEndOfInput().WithMessage("(1, 2): B expected");
-        Choice(C, AB, NeverExecuted).FailsToParse("A").AtEndOfInput().WithMessage("(1, 2): B expected");
+        Choice(AB, NeverExecuted).FailsToParse("A").WithMessage("(1, 2): B expected");
+        Choice(C, AB, NeverExecuted).FailsToParse("A").WithMessage("(1, 2): B expected");
     }
 
     public void MergesErrorMessagesWhenParsersFailWithoutConsumingInput()
     {
-        Choice(A, B).FailsToParse("").AtEndOfInput().WithMessage("(1, 1): A or B expected");
-        Choice(A, B, C).FailsToParse("").AtEndOfInput().WithMessage("(1, 1): A, B or C expected");
+        Choice(A, B).FailsToParse("").WithMessage("(1, 1): A or B expected");
+        Choice(A, B, C).FailsToParse("").WithMessage("(1, 1): A, B or C expected");
     }
 
     public void MergesPotentialErrorMessagesWhenParserSucceedsWithoutConsumingInput()

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -67,7 +67,7 @@ class GrammarTests
         parser.FailsToParse("ABABA!", "!")
             .WithMessage("(1, 6): B expected");
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input.Position, input.EndOfInput);
+        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input.Position);
         Action infiniteLoop = () => ZeroOrMore(succeedWithoutConsuming)(new Text(""));
 
         infiniteLoop
@@ -91,7 +91,7 @@ class GrammarTests
         parser.FailsToParse("ABABA!", "!")
             .WithMessage("(1, 6): B expected");
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input.Position, input.EndOfInput);
+        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input.Position);
         Action infiniteLoop = () => OneOrMore(succeedWithoutConsuming)(new Text(""));
 
         infiniteLoop
@@ -308,7 +308,7 @@ public class AlternationTests
         //consuming input.  These tests simply describe the behavior under that
         //unusual situation.
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input.Position, input.EndOfInput);
+        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input.Position);
 
         var reply = Choice(A, succeedWithoutConsuming).Parses("");
         reply.ErrorMessages.ToString().ShouldBe("A expected");

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -67,7 +67,7 @@ class GrammarTests
         parser.FailsToParse("ABABA!", "!")
             .WithMessage("(1, 6): B expected");
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input, input.Position, input.EndOfInput);
+        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input.Position, input.EndOfInput);
         Action infiniteLoop = () => ZeroOrMore(succeedWithoutConsuming)(new Text(""));
 
         infiniteLoop
@@ -91,7 +91,7 @@ class GrammarTests
         parser.FailsToParse("ABABA!", "!")
             .WithMessage("(1, 6): B expected");
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input, input.Position, input.EndOfInput);
+        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input.Position, input.EndOfInput);
         Action infiniteLoop = () => OneOrMore(succeedWithoutConsuming)(new Text(""));
 
         infiniteLoop
@@ -308,7 +308,7 @@ public class AlternationTests
         //consuming input.  These tests simply describe the behavior under that
         //unusual situation.
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input, input.Position, input.EndOfInput);
+        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input.Position, input.EndOfInput);
 
         var reply = Choice(A, succeedWithoutConsuming).Parses("");
         reply.ErrorMessages.ToString().ShouldBe("A expected");

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammarTests.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammarTests.cs
@@ -104,10 +104,10 @@ class JsonGrammarTests
 
     public void RequiresEndOfInputAfterFirstValidJsonValue()
     {
-        JsonDocument.FailsToParse("true $garbage$", "$garbage$").WithMessage("(1, 6): end of input expected");
-        JsonDocument.FailsToParse("10.123E-11  $garbage$", "$garbage$").WithMessage("(1, 13): end of input expected");
-        JsonDocument.FailsToParse("\"garbage\" $garbage$", "$garbage$").WithMessage("(1, 11): end of input expected");
-        JsonDocument.FailsToParse("[0, 1, 2] $garbage$", "$garbage$").WithMessage("(1, 11): end of input expected");
-        JsonDocument.FailsToParse("{\"zero\" : 0} $garbage$", "$garbage$").WithMessage("(1, 14): end of input expected");
+        JsonDocument.FailsToParse("true $garbage$", "$garbage$", "(1, 6): end of input expected");
+        JsonDocument.FailsToParse("10.123E-11  $garbage$", "$garbage$", "(1, 13): end of input expected");
+        JsonDocument.FailsToParse("\"garbage\" $garbage$", "$garbage$", "(1, 11): end of input expected");
+        JsonDocument.FailsToParse("[0, 1, 2] $garbage$", "$garbage$", "(1, 11): end of input expected");
+        JsonDocument.FailsToParse("{\"zero\" : 0} $garbage$", "$garbage$", "(1, 14): end of input expected");
     }
 }

--- a/src/Parsley.Tests/OperatorPrecedenceParserTests.cs
+++ b/src/Parsley.Tests/OperatorPrecedenceParserTests.cs
@@ -98,7 +98,7 @@ class OperatorPrecedenceParserTests
         //The "(" unit-parser is invoked but fails.  The next token, "*", has
         //high precedence, but that should not provoke parsing to continue.
             
-        expression.Parser.FailsToParse("(*", "*").WithMessage("(1, 2): Parse error.");
+        expression.Parser.FailsToParse("(*", "*", "(1, 2): Parse error.");
     }
 
     public void ProvidesErrorAtAppropriatePositionWhenExtendParsersFail()
@@ -110,7 +110,7 @@ class OperatorPrecedenceParserTests
         //is invoked and immediately fails.  The next token, "*", has
         //high precedence, but that should not provoke parsing to continue.
 
-        expression.Parser.FailsToParse("2-*", "*").WithMessage("(1, 3): Parse error.");
+        expression.Parser.FailsToParse("2-*", "*", "(1, 3): Parse error.");
     }
 
     void Parses(string input, string expectedTree)

--- a/src/Parsley.Tests/ParsedTests.cs
+++ b/src/Parsley.Tests/ParsedTests.cs
@@ -11,12 +11,12 @@ class ParsedTests
 
     public void HasAParsedValue()
     {
-        new Parsed<string>("parsed", unparsed).Value.ShouldBe("parsed");
+        new Parsed<string>("parsed", unparsed, unparsed.Position, unparsed.EndOfInput).Value.ShouldBe("parsed");
     }
 
     public void HasNoErrorMessageByDefault()
     {
-        new Parsed<string>("x", unparsed).ErrorMessages.ShouldBe(ErrorMessageList.Empty);
+        new Parsed<string>("x", unparsed, unparsed.Position, unparsed.EndOfInput).ErrorMessages.ShouldBe(ErrorMessageList.Empty);
     }
 
     public void CanIndicatePotentialErrors()
@@ -25,16 +25,16 @@ class ParsedTests
             .With(ErrorMessage.Expected("A"))
             .With(ErrorMessage.Expected("B"));
 
-        new Parsed<object>("x", unparsed, potentialErrors).ErrorMessages.ShouldBe(potentialErrors);
+        new Parsed<object>("x", unparsed, unparsed.Position, unparsed.EndOfInput, potentialErrors).ErrorMessages.ShouldBe(potentialErrors);
     }
 
     public void HasRemainingUnparsedInput()
     {
-        new Parsed<string>("parsed", unparsed).UnparsedInput.ShouldBe(unparsed);
+        new Parsed<string>("parsed", unparsed, unparsed.Position, unparsed.EndOfInput).UnparsedInput.ShouldBe(unparsed);
     }
 
     public void ReportsNonerrorState()
     {
-        new Parsed<string>("parsed", unparsed).Success.ShouldBeTrue();
+        new Parsed<string>("parsed", unparsed, unparsed.Position, unparsed.EndOfInput).Success.ShouldBeTrue();
     }
 }

--- a/src/Parsley.Tests/ParsedTests.cs
+++ b/src/Parsley.Tests/ParsedTests.cs
@@ -11,12 +11,12 @@ class ParsedTests
 
     public void HasAParsedValue()
     {
-        new Parsed<string>("parsed", unparsed.Position, unparsed.EndOfInput).Value.ShouldBe("parsed");
+        new Parsed<string>("parsed", unparsed.Position).Value.ShouldBe("parsed");
     }
 
     public void HasNoErrorMessageByDefault()
     {
-        new Parsed<string>("x", unparsed.Position, unparsed.EndOfInput).ErrorMessages.ShouldBe(ErrorMessageList.Empty);
+        new Parsed<string>("x", unparsed.Position).ErrorMessages.ShouldBe(ErrorMessageList.Empty);
     }
 
     public void CanIndicatePotentialErrors()
@@ -25,18 +25,17 @@ class ParsedTests
             .With(ErrorMessage.Expected("A"))
             .With(ErrorMessage.Expected("B"));
 
-        new Parsed<object>("x", unparsed.Position, unparsed.EndOfInput, potentialErrors).ErrorMessages.ShouldBe(potentialErrors);
+        new Parsed<object>("x", unparsed.Position, potentialErrors).ErrorMessages.ShouldBe(potentialErrors);
     }
 
     public void HasRemainingUnparsedInput()
     {
-        var parsed = new Parsed<string>("parsed", unparsed.Position, unparsed.EndOfInput);
+        var parsed = new Parsed<string>("parsed", unparsed.Position);
         parsed.Position.ShouldBe(unparsed.Position);
-        parsed.EndOfInput.ShouldBe(unparsed.EndOfInput);
     }
 
     public void ReportsNonerrorState()
     {
-        new Parsed<string>("parsed", unparsed.Position, unparsed.EndOfInput).Success.ShouldBeTrue();
+        new Parsed<string>("parsed", unparsed.Position).Success.ShouldBeTrue();
     }
 }

--- a/src/Parsley.Tests/ParsedTests.cs
+++ b/src/Parsley.Tests/ParsedTests.cs
@@ -11,12 +11,12 @@ class ParsedTests
 
     public void HasAParsedValue()
     {
-        new Parsed<string>("parsed", unparsed, unparsed.Position, unparsed.EndOfInput).Value.ShouldBe("parsed");
+        new Parsed<string>("parsed", unparsed.Position, unparsed.EndOfInput).Value.ShouldBe("parsed");
     }
 
     public void HasNoErrorMessageByDefault()
     {
-        new Parsed<string>("x", unparsed, unparsed.Position, unparsed.EndOfInput).ErrorMessages.ShouldBe(ErrorMessageList.Empty);
+        new Parsed<string>("x", unparsed.Position, unparsed.EndOfInput).ErrorMessages.ShouldBe(ErrorMessageList.Empty);
     }
 
     public void CanIndicatePotentialErrors()
@@ -25,18 +25,18 @@ class ParsedTests
             .With(ErrorMessage.Expected("A"))
             .With(ErrorMessage.Expected("B"));
 
-        new Parsed<object>("x", unparsed, unparsed.Position, unparsed.EndOfInput, potentialErrors).ErrorMessages.ShouldBe(potentialErrors);
+        new Parsed<object>("x", unparsed.Position, unparsed.EndOfInput, potentialErrors).ErrorMessages.ShouldBe(potentialErrors);
     }
 
     public void HasRemainingUnparsedInput()
     {
-        var parsed = new Parsed<string>("parsed", unparsed, unparsed.Position, unparsed.EndOfInput);
+        var parsed = new Parsed<string>("parsed", unparsed.Position, unparsed.EndOfInput);
         parsed.Position.ShouldBe(unparsed.Position);
         parsed.EndOfInput.ShouldBe(unparsed.EndOfInput);
     }
 
     public void ReportsNonerrorState()
     {
-        new Parsed<string>("parsed", unparsed, unparsed.Position, unparsed.EndOfInput).Success.ShouldBeTrue();
+        new Parsed<string>("parsed", unparsed.Position, unparsed.EndOfInput).Success.ShouldBeTrue();
     }
 }

--- a/src/Parsley.Tests/ParsedTests.cs
+++ b/src/Parsley.Tests/ParsedTests.cs
@@ -30,7 +30,9 @@ class ParsedTests
 
     public void HasRemainingUnparsedInput()
     {
-        new Parsed<string>("parsed", unparsed, unparsed.Position, unparsed.EndOfInput).UnparsedInput.ShouldBe(unparsed);
+        var parsed = new Parsed<string>("parsed", unparsed, unparsed.Position, unparsed.EndOfInput);
+        parsed.Position.ShouldBe(unparsed.Position);
+        parsed.EndOfInput.ShouldBe(unparsed.EndOfInput);
     }
 
     public void ReportsNonerrorState()

--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using static Parsley.Grammar;
 
 namespace Parsley.Tests;
 
@@ -7,9 +6,10 @@ class ParserQueryTests
 {
     static readonly Parser<string> Next = input =>
     {
-        var unparsedInput = input.Advance(1);
+        var next = input.Peek(1);
+        input.Advance(1);
 
-        return new Parsed<string>(input.Peek(1), unparsedInput, unparsedInput.Position, unparsedInput.EndOfInput);
+        return new Parsed<string>(next, input, input.Position, input.EndOfInput);
     };
 
     public void CanBuildParserWhichSimulatesSuccessfulParsingOfGivenValueWithoutConsumingInput()

--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -9,7 +9,7 @@ class ParserQueryTests
         var next = input.Peek(1);
         input.Advance(1);
 
-        return new Parsed<string>(next, input.Position, input.EndOfInput);
+        return new Parsed<string>(next, input.Position);
     };
 
     public void CanBuildParserWhichSimulatesSuccessfulParsingOfGivenValueWithoutConsumingInput()

--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -9,7 +9,7 @@ class ParserQueryTests
         var next = input.Peek(1);
         input.Advance(1);
 
-        return new Parsed<string>(next, input, input.Position, input.EndOfInput);
+        return new Parsed<string>(next, input.Position, input.EndOfInput);
     };
 
     public void CanBuildParserWhichSimulatesSuccessfulParsingOfGivenValueWithoutConsumingInput()

--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -5,7 +5,12 @@ namespace Parsley.Tests;
 
 class ParserQueryTests
 {
-    static readonly Parser<string> Next = input => new Parsed<string>(input.Peek(1), input.Advance(1));
+    static readonly Parser<string> Next = input =>
+    {
+        var unparsedInput = input.Advance(1);
+
+        return new Parsed<string>(input.Peek(1), unparsedInput, unparsedInput.Position, unparsedInput.EndOfInput);
+    };
 
     public void CanBuildParserWhichSimulatesSuccessfulParsingOfGivenValueWithoutConsumingInput()
     {

--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -44,16 +44,16 @@ class ParserQueryTests
         (from _ in Fail
             from x in Next
             from y in Next
-            select Tuple.Create(x, y)).FailsToParse("xy", "xy");
+            select Tuple.Create(x, y)).FailsToParse("xy", "xy", "(1, 1): Parse error.");
 
         (from x in Next
             from _ in Fail
             from y in Next
-            select Tuple.Create(x, y)).FailsToParse("xy", "y");
+            select Tuple.Create(x, y)).FailsToParse("xy", "y", "(1, 2): Parse error.");
 
         (from x in Next
             from y in Next
             from _ in Fail
-            select Tuple.Create(x, y)).FailsToParse("xy");
+            select Tuple.Create(x, y)).FailsToParse("xy", "", "(1, 3): Parse error.");
     }
 }

--- a/src/Parsley.Tests/TextTests.cs
+++ b/src/Parsley.Tests/TextTests.cs
@@ -19,19 +19,40 @@ class TextTests
         abc.Peek(100).ShouldBe("abc");
     }
 
-    public void CanAdvanceAheadNCharacters()
+    public void CanAdvanceAheadNCharactersWithSnapshotBacktracking()
     {
         var empty = new Text("");
-        empty.Advance(0).ToString().ShouldBe("");
-        empty.Advance(1).ToString().ShouldBe("");
+
+        empty.Advance(0);
+        empty.ToString().ShouldBe("");
+
+        empty.Advance(1);
+        empty.ToString().ShouldBe("");
 
         var abc = new Text("abc");
-        abc.Advance(0).ToString().ShouldBe("abc");
-        abc.Advance(1).ToString().ShouldBe("bc");
-        abc.Advance(2).ToString().ShouldBe("c");
-        abc.Advance(3).ToString().ShouldBe("");
-        abc.Advance(4).ToString().ShouldBe("");
-        abc.Advance(100).ToString().ShouldBe("");
+
+        abc.Advance(0);
+        abc.ToString().ShouldBe("abc");
+
+        var snapshot = abc.Snapshot();
+        abc.Advance(1);
+        abc.ToString().ShouldBe("bc");
+
+        abc.Restore(snapshot);
+        abc.Advance(2);
+        abc.ToString().ShouldBe("c");
+
+        abc.Restore(snapshot);
+        abc.Advance(3);
+        abc.ToString().ShouldBe("");
+
+        abc.Restore(snapshot);
+        abc.Advance(4);
+        abc.ToString().ShouldBe("");
+
+        abc.Restore(snapshot);
+        abc.Advance(100);
+        abc.ToString().ShouldBe("");
     }
 
     public void DetectsTheEndOfInput()
@@ -56,17 +77,20 @@ class TextTests
         abc123.Match(letters).ShouldSucceed("abc");
         abc123.Match(alphanumerics).ShouldSucceed("abc123");
 
-        abc123.Advance(2).Match(digits).ShouldFail();
-        abc123.Advance(2).Match(letters).ShouldSucceed("c");
-        abc123.Advance(2).Match(alphanumerics).ShouldSucceed("c123");
+        abc123.Advance(2);
+        abc123.Match(digits).ShouldFail();
+        abc123.Match(letters).ShouldSucceed("c");
+        abc123.Match(alphanumerics).ShouldSucceed("c123");
 
-        abc123.Advance(3).Match(digits).ShouldSucceed("123");
-        abc123.Advance(3).Match(letters).ShouldFail();
-        abc123.Advance(3).Match(alphanumerics).ShouldSucceed("123");
+        abc123.Advance(1);
+        abc123.Match(digits).ShouldSucceed("123");
+        abc123.Match(letters).ShouldFail();
+        abc123.Match(alphanumerics).ShouldSucceed("123");
 
-        abc123.Advance(6).Match(digits).ShouldFail();
-        abc123.Advance(6).Match(letters).ShouldFail();
-        abc123.Advance(6).Match(alphanumerics).ShouldFail();
+        abc123.Advance(3);
+        abc123.Match(digits).ShouldFail();
+        abc123.Match(letters).ShouldFail();
+        abc123.Match(alphanumerics).ShouldFail();
     }
 
     public void CanMatchLeadingCharactersByPredicate()
@@ -83,24 +107,27 @@ class TextTests
         abc123.Match(letters).ShouldSucceed("abc");
         abc123.Match(alphanumerics).ShouldSucceed("abc123");
 
-        abc123.Advance(2).Match(digits).ShouldFail();
-        abc123.Advance(2).Match(letters).ShouldSucceed("c");
-        abc123.Advance(2).Match(alphanumerics).ShouldSucceed("c123");
+        abc123.Advance(2);
+        abc123.Match(digits).ShouldFail();
+        abc123.Match(letters).ShouldSucceed("c");
+        abc123.Match(alphanumerics).ShouldSucceed("c123");
 
-        abc123.Advance(3).Match(digits).ShouldSucceed("123");
-        abc123.Advance(3).Match(letters).ShouldFail();
-        abc123.Advance(3).Match(alphanumerics).ShouldSucceed("123");
+        abc123.Advance(1);
+        abc123.Match(digits).ShouldSucceed("123");
+        abc123.Match(letters).ShouldFail();
+        abc123.Match(alphanumerics).ShouldSucceed("123");
 
-        abc123.Advance(6).Match(digits).ShouldFail();
-        abc123.Advance(6).Match(letters).ShouldFail();
-        abc123.Advance(6).Match(alphanumerics).ShouldFail();
+        abc123.Advance(3);
+        abc123.Match(digits).ShouldFail();
+        abc123.Match(letters).ShouldFail();
+        abc123.Match(alphanumerics).ShouldFail();
     }
 
     public void CanGetCurrentPosition()
     {
         var empty = new Text("");
-        empty.Advance(0).Position.ShouldBe(new Position(1, 1));
-        empty.Advance(1).Position.ShouldBe(new Position(1, 1));
+        empty.Advance(0);empty.Position.ShouldBe(new Position(1, 1));
+        empty.Advance(1);empty.Position.ShouldBe(new Position(1, 1));
 
         var lines = new StringBuilder()
             .Append("Line 1\n")//Index 0-5, \n
@@ -108,19 +135,51 @@ class TextTests
             .Append("Line 3\n");//Index 14-19, \n
         var list = new Text(lines.ToString());
 
-        list.Advance(0).Position.ShouldBe(new Position(1, 1));
-        list.Advance(5).Position.ShouldBe(new Position(1, 6));
-        list.Advance(6).Position.ShouldBe(new Position(1, 7));
+        var snapshot = list.Snapshot();
+        list.Advance(0);
+        list.Position.ShouldBe(new Position(1, 1));
 
-        list.Advance(7).Position.ShouldBe(new Position(2, 1));
-        list.Advance(12).Position.ShouldBe(new Position(2, 6));
-        list.Advance(13).Position.ShouldBe(new Position(2, 7));
+        list.Restore(snapshot);
+        list.Advance(5);
+        list.Position.ShouldBe(new Position(1, 6));
 
-        list.Advance(14).Position.ShouldBe(new Position(3, 1));
-        list.Advance(19).Position.ShouldBe(new Position(3, 6));
-        list.Advance(20).Position.ShouldBe(new Position(3, 7));
+        list.Restore(snapshot);
+        list.Advance(6);
+        list.Position.ShouldBe(new Position(1, 7));
 
-        list.Advance(21).Position.ShouldBe(new Position(4, 1));
-        list.Advance(1000).Position.ShouldBe(new Position(4, 1));
+
+        list.Restore(snapshot);
+        list.Advance(7);
+        list.Position.ShouldBe(new Position(2, 1));
+
+        list.Restore(snapshot);
+        list.Advance(12);
+        list.Position.ShouldBe(new Position(2, 6));
+
+        list.Restore(snapshot);
+        list.Advance(13);
+        list.Position.ShouldBe(new Position(2, 7));
+
+
+        list.Restore(snapshot);
+        list.Advance(14);
+        list.Position.ShouldBe(new Position(3, 1));
+
+        list.Restore(snapshot);
+        list.Advance(19);
+        list.Position.ShouldBe(new Position(3, 6));
+
+        list.Restore(snapshot);
+        list.Advance(20);
+        list.Position.ShouldBe(new Position(3, 7));
+
+
+        list.Restore(snapshot);
+        list.Advance(21);
+        list.Position.ShouldBe(new Position(4, 1));
+
+        list.Restore(snapshot);
+        list.Advance(1000);
+        list.Position.ShouldBe(new Position(4, 1));
     }
 }

--- a/src/Parsley/Error.cs
+++ b/src/Parsley/Error.cs
@@ -2,19 +2,17 @@ namespace Parsley;
 
 public class Error<T> : Reply<T>
 {
-    public Error(Position position, bool endOfInput, ErrorMessage error)
-        : this(position, endOfInput, ErrorMessageList.Empty.With(error)) { }
+    public Error(Position position, ErrorMessage error)
+        : this(position, ErrorMessageList.Empty.With(error)) { }
 
-    public Error(Position position, bool endOfInput, ErrorMessageList errors)
+    public Error(Position position, ErrorMessageList errors)
     {
         Position = position;
-        EndOfInput = endOfInput;
         ErrorMessages = errors;
     }
 
     public T Value => throw new MemberAccessException($"{Position}: {ErrorMessages}");
     public Position Position { get; }
-    public bool EndOfInput { get; }
     public bool Success => false;
     public ErrorMessageList ErrorMessages { get; }
 }

--- a/src/Parsley/Error.cs
+++ b/src/Parsley/Error.cs
@@ -8,6 +8,8 @@ public class Error<T> : Reply<T>
     public Error(Text unparsedInput, ErrorMessageList errors)
     {
         UnparsedInput = unparsedInput;
+        Position = unparsedInput.Position;
+        EndOfInput = unparsedInput.EndOfInput;
         ErrorMessages = errors;
     }
 
@@ -21,6 +23,8 @@ public class Error<T> : Reply<T>
     }
 
     public Text UnparsedInput { get; }
+    public Position Position { get; }
+    public bool EndOfInput { get; }
     public bool Success => false;
     public ErrorMessageList ErrorMessages { get; }
 }

--- a/src/Parsley/Error.cs
+++ b/src/Parsley/Error.cs
@@ -2,19 +2,17 @@ namespace Parsley;
 
 public class Error<T> : Reply<T>
 {
-    public Error(Text unparsedInput, Position position, bool endOfInput, ErrorMessage error)
-        : this(unparsedInput, position, endOfInput, ErrorMessageList.Empty.With(error)) { }
+    public Error(Position position, bool endOfInput, ErrorMessage error)
+        : this(position, endOfInput, ErrorMessageList.Empty.With(error)) { }
 
-    public Error(Text unparsedInput, Position position, bool endOfInput, ErrorMessageList errors)
+    public Error(Position position, bool endOfInput, ErrorMessageList errors)
     {
-        UnparsedInput = unparsedInput;
         Position = position;
         EndOfInput = endOfInput;
         ErrorMessages = errors;
     }
 
     public T Value => throw new MemberAccessException($"{Position}: {ErrorMessages}");
-    public Text UnparsedInput { get; }
     public Position Position { get; }
     public bool EndOfInput { get; }
     public bool Success => false;

--- a/src/Parsley/Error.cs
+++ b/src/Parsley/Error.cs
@@ -2,26 +2,18 @@ namespace Parsley;
 
 public class Error<T> : Reply<T>
 {
-    public Error(Text unparsedInput, ErrorMessage error)
-        : this(unparsedInput,  ErrorMessageList.Empty.With(error)) { }
+    public Error(Text unparsedInput, Position position, bool endOfInput, ErrorMessage error)
+        : this(unparsedInput, position, endOfInput, ErrorMessageList.Empty.With(error)) { }
 
-    public Error(Text unparsedInput, ErrorMessageList errors)
+    public Error(Text unparsedInput, Position position, bool endOfInput, ErrorMessageList errors)
     {
         UnparsedInput = unparsedInput;
-        Position = unparsedInput.Position;
-        EndOfInput = unparsedInput.EndOfInput;
+        Position = position;
+        EndOfInput = endOfInput;
         ErrorMessages = errors;
     }
 
-    public T Value
-    {
-        get
-        {
-            var position = UnparsedInput.Position;
-            throw new MemberAccessException($"{position}: {ErrorMessages}");
-        }
-    }
-
+    public T Value => throw new MemberAccessException($"{Position}: {ErrorMessages}");
     public Text UnparsedInput { get; }
     public Position Position { get; }
     public bool EndOfInput { get; }

--- a/src/Parsley/Grammar.Attempt.cs
+++ b/src/Parsley/Grammar.Attempt.cs
@@ -18,7 +18,7 @@ partial class Grammar
             if (reply.Success || start == newPosition)
                 return reply;
 
-            return new Error<T>(input, ErrorMessage.Backtrack(newPosition, reply.ErrorMessages));
+            return new Error<T>(input, input.Position, input.EndOfInput, ErrorMessage.Backtrack(newPosition, reply.ErrorMessages));
         };
     }
 }

--- a/src/Parsley/Grammar.Attempt.cs
+++ b/src/Parsley/Grammar.Attempt.cs
@@ -20,7 +20,7 @@ partial class Grammar
                 return reply;
 
             input.Restore(snapshot);
-            return new Error<T>(input.Position, input.EndOfInput, ErrorMessage.Backtrack(newPosition, reply.ErrorMessages));
+            return new Error<T>(input.Position, ErrorMessage.Backtrack(newPosition, reply.ErrorMessages));
         };
     }
 }

--- a/src/Parsley/Grammar.Attempt.cs
+++ b/src/Parsley/Grammar.Attempt.cs
@@ -14,7 +14,7 @@ partial class Grammar
             var snapshot = input.Snapshot();
             var start = input.Position;
             var reply = parse(input);
-            var newPosition = reply.Position;
+            var newPosition = input.Position;
 
             if (reply.Success || start == newPosition)
                 return reply;

--- a/src/Parsley/Grammar.Attempt.cs
+++ b/src/Parsley/Grammar.Attempt.cs
@@ -13,7 +13,7 @@ partial class Grammar
         {
             var start = input.Position;
             var reply = parse(input);
-            var newPosition = reply.UnparsedInput.Position;
+            var newPosition = reply.Position;
 
             if (reply.Success || start == newPosition)
                 return reply;

--- a/src/Parsley/Grammar.Attempt.cs
+++ b/src/Parsley/Grammar.Attempt.cs
@@ -20,7 +20,7 @@ partial class Grammar
                 return reply;
 
             input.Restore(snapshot);
-            return new Error<T>(input, input.Position, input.EndOfInput, ErrorMessage.Backtrack(newPosition, reply.ErrorMessages));
+            return new Error<T>(input.Position, input.EndOfInput, ErrorMessage.Backtrack(newPosition, reply.ErrorMessages));
         };
     }
 }

--- a/src/Parsley/Grammar.Attempt.cs
+++ b/src/Parsley/Grammar.Attempt.cs
@@ -11,6 +11,7 @@ partial class Grammar
     {
         return input =>
         {
+            var snapshot = input.Snapshot();
             var start = input.Position;
             var reply = parse(input);
             var newPosition = reply.Position;
@@ -18,6 +19,7 @@ partial class Grammar
             if (reply.Success || start == newPosition)
                 return reply;
 
+            input.Restore(snapshot);
             return new Error<T>(input, input.Position, input.EndOfInput, ErrorMessage.Backtrack(newPosition, reply.ErrorMessages));
         };
     }

--- a/src/Parsley/Grammar.Choice.cs
+++ b/src/Parsley/Grammar.Choice.cs
@@ -47,9 +47,9 @@ partial class Grammar
                 errors = errors.Merge(reply.ErrorMessages);
 
                 if (reply.Success)
-                    reply = new Parsed<T>(reply.Value, reply.Position, reply.EndOfInput, errors);
+                    reply = new Parsed<T>(reply.Value, reply.Position, errors);
                 else
-                    reply = new Error<T>(reply.Position, reply.EndOfInput, errors);
+                    reply = new Error<T>(reply.Position, errors);
             }
 
             return reply;

--- a/src/Parsley/Grammar.Choice.cs
+++ b/src/Parsley/Grammar.Choice.cs
@@ -29,7 +29,7 @@ partial class Grammar
         {
             var start = input.Position;
             var reply = parsers[0](input);
-            var newPosition = reply.UnparsedInput.Position;
+            var newPosition = reply.Position;
 
             var errors = ErrorMessageList.Empty;
             var i = 1;
@@ -38,7 +38,7 @@ partial class Grammar
             {
                 errors = errors.Merge(reply.ErrorMessages);
                 reply = parsers[i](input);
-                newPosition = reply.UnparsedInput.Position;
+                newPosition = reply.Position;
                 i++;
             }
 

--- a/src/Parsley/Grammar.Choice.cs
+++ b/src/Parsley/Grammar.Choice.cs
@@ -47,9 +47,9 @@ partial class Grammar
                 errors = errors.Merge(reply.ErrorMessages);
 
                 if (reply.Success)
-                    reply = new Parsed<T>(reply.Value, reply.UnparsedInput, reply.UnparsedInput.Position, reply.UnparsedInput.EndOfInput, errors);
+                    reply = new Parsed<T>(reply.Value, reply.UnparsedInput, reply.Position, reply.EndOfInput, errors);
                 else
-                    reply = new Error<T>(reply.UnparsedInput, reply.UnparsedInput.Position, reply.UnparsedInput.EndOfInput, errors);
+                    reply = new Error<T>(reply.UnparsedInput, reply.Position, reply.EndOfInput, errors);
             }
 
             return reply;

--- a/src/Parsley/Grammar.Choice.cs
+++ b/src/Parsley/Grammar.Choice.cs
@@ -29,7 +29,7 @@ partial class Grammar
         {
             var start = input.Position;
             var reply = parsers[0](input);
-            var newPosition = reply.Position;
+            var newPosition = input.Position;
 
             var errors = ErrorMessageList.Empty;
             var i = 1;
@@ -38,7 +38,7 @@ partial class Grammar
             {
                 errors = errors.Merge(reply.ErrorMessages);
                 reply = parsers[i](input);
-                newPosition = reply.Position;
+                newPosition = input.Position;
                 i++;
             }
 

--- a/src/Parsley/Grammar.Choice.cs
+++ b/src/Parsley/Grammar.Choice.cs
@@ -47,9 +47,9 @@ partial class Grammar
                 errors = errors.Merge(reply.ErrorMessages);
 
                 if (reply.Success)
-                    reply = new Parsed<T>(reply.Value, reply.UnparsedInput, errors);
+                    reply = new Parsed<T>(reply.Value, reply.UnparsedInput, reply.UnparsedInput.Position, reply.UnparsedInput.EndOfInput, errors);
                 else
-                    reply = new Error<T>(reply.UnparsedInput, errors);
+                    reply = new Error<T>(reply.UnparsedInput, reply.UnparsedInput.Position, reply.UnparsedInput.EndOfInput, errors);
             }
 
             return reply;

--- a/src/Parsley/Grammar.Choice.cs
+++ b/src/Parsley/Grammar.Choice.cs
@@ -47,9 +47,9 @@ partial class Grammar
                 errors = errors.Merge(reply.ErrorMessages);
 
                 if (reply.Success)
-                    reply = new Parsed<T>(reply.Value, reply.UnparsedInput, reply.Position, reply.EndOfInput, errors);
+                    reply = new Parsed<T>(reply.Value, reply.Position, reply.EndOfInput, errors);
                 else
-                    reply = new Error<T>(reply.UnparsedInput, reply.Position, reply.EndOfInput, errors);
+                    reply = new Error<T>(reply.Position, reply.EndOfInput, errors);
             }
 
             return reply;

--- a/src/Parsley/Grammar.EndOfInput.cs
+++ b/src/Parsley/Grammar.EndOfInput.cs
@@ -4,6 +4,6 @@ partial class Grammar
 {
     public static readonly Parser<string> EndOfInput =
         input => input.EndOfInput
-            ? new Parsed<string>("", input)
-            : new Error<string>(input, ErrorMessage.Expected("end of input"));
+            ? new Parsed<string>("", input, input.Position, input.EndOfInput)
+            : new Error<string>(input, input.Position, input.EndOfInput, ErrorMessage.Expected("end of input"));
 }

--- a/src/Parsley/Grammar.EndOfInput.cs
+++ b/src/Parsley/Grammar.EndOfInput.cs
@@ -4,6 +4,6 @@ partial class Grammar
 {
     public static readonly Parser<string> EndOfInput =
         input => input.EndOfInput
-            ? new Parsed<string>("", input, input.Position, input.EndOfInput)
-            : new Error<string>(input, input.Position, input.EndOfInput, ErrorMessage.Expected("end of input"));
+            ? new Parsed<string>("", input.Position, input.EndOfInput)
+            : new Error<string>(input.Position, input.EndOfInput, ErrorMessage.Expected("end of input"));
 }

--- a/src/Parsley/Grammar.EndOfInput.cs
+++ b/src/Parsley/Grammar.EndOfInput.cs
@@ -4,6 +4,6 @@ partial class Grammar
 {
     public static readonly Parser<string> EndOfInput =
         input => input.EndOfInput
-            ? new Parsed<string>("", input.Position, input.EndOfInput)
-            : new Error<string>(input.Position, input.EndOfInput, ErrorMessage.Expected("end of input"));
+            ? new Parsed<string>("", input.Position)
+            : new Error<string>(input.Position, ErrorMessage.Expected("end of input"));
 }

--- a/src/Parsley/Grammar.Fail.cs
+++ b/src/Parsley/Grammar.Fail.cs
@@ -2,5 +2,5 @@ namespace Parsley;
 
 public partial class Grammar<T>
 {
-    public static readonly Parser<T> Fail = input => new Error<T>(input, input.Position, input.EndOfInput, ErrorMessage.Unknown());
+    public static readonly Parser<T> Fail = input => new Error<T>(input.Position, input.EndOfInput, ErrorMessage.Unknown());
 }

--- a/src/Parsley/Grammar.Fail.cs
+++ b/src/Parsley/Grammar.Fail.cs
@@ -2,5 +2,5 @@ namespace Parsley;
 
 public partial class Grammar<T>
 {
-    public static readonly Parser<T> Fail = input => new Error<T>(input, ErrorMessage.Unknown());
+    public static readonly Parser<T> Fail = input => new Error<T>(input, input.Position, input.EndOfInput, ErrorMessage.Unknown());
 }

--- a/src/Parsley/Grammar.Fail.cs
+++ b/src/Parsley/Grammar.Fail.cs
@@ -2,5 +2,5 @@ namespace Parsley;
 
 public partial class Grammar<T>
 {
-    public static readonly Parser<T> Fail = input => new Error<T>(input.Position, input.EndOfInput, ErrorMessage.Unknown());
+    public static readonly Parser<T> Fail = input => new Error<T>(input.Position, ErrorMessage.Unknown());
 }

--- a/src/Parsley/Grammar.Label.cs
+++ b/src/Parsley/Grammar.Label.cs
@@ -20,9 +20,9 @@ partial class Grammar
             if (start == newPosition)
             {
                 if (reply.Success)
-                    reply = new Parsed<T>(reply.Value, reply.UnparsedInput, reply.UnparsedInput.Position, reply.UnparsedInput.EndOfInput, errors);
+                    reply = new Parsed<T>(reply.Value, reply.UnparsedInput, reply.Position, reply.EndOfInput, errors);
                 else
-                    reply = new Error<T>(reply.UnparsedInput, reply.UnparsedInput.Position, reply.UnparsedInput.EndOfInput, errors);
+                    reply = new Error<T>(reply.UnparsedInput, reply.Position, reply.EndOfInput, errors);
             }
 
             return reply;

--- a/src/Parsley/Grammar.Label.cs
+++ b/src/Parsley/Grammar.Label.cs
@@ -15,7 +15,7 @@ partial class Grammar
         {
             var start = input.Position;
             var reply = parse(input);
-            var newPosition = reply.Position;
+            var newPosition = input.Position;
 
             if (start == newPosition)
             {

--- a/src/Parsley/Grammar.Label.cs
+++ b/src/Parsley/Grammar.Label.cs
@@ -20,9 +20,9 @@ partial class Grammar
             if (start == newPosition)
             {
                 if (reply.Success)
-                    reply = new Parsed<T>(reply.Value, reply.UnparsedInput, reply.Position, reply.EndOfInput, errors);
+                    reply = new Parsed<T>(reply.Value, reply.Position, reply.EndOfInput, errors);
                 else
-                    reply = new Error<T>(reply.UnparsedInput, reply.Position, reply.EndOfInput, errors);
+                    reply = new Error<T>(reply.Position, reply.EndOfInput, errors);
             }
 
             return reply;

--- a/src/Parsley/Grammar.Label.cs
+++ b/src/Parsley/Grammar.Label.cs
@@ -20,9 +20,9 @@ partial class Grammar
             if (start == newPosition)
             {
                 if (reply.Success)
-                    reply = new Parsed<T>(reply.Value, reply.UnparsedInput, errors);
+                    reply = new Parsed<T>(reply.Value, reply.UnparsedInput, reply.UnparsedInput.Position, reply.UnparsedInput.EndOfInput, errors);
                 else
-                    reply = new Error<T>(reply.UnparsedInput, errors);
+                    reply = new Error<T>(reply.UnparsedInput, reply.UnparsedInput.Position, reply.UnparsedInput.EndOfInput, errors);
             }
 
             return reply;

--- a/src/Parsley/Grammar.Label.cs
+++ b/src/Parsley/Grammar.Label.cs
@@ -20,9 +20,9 @@ partial class Grammar
             if (start == newPosition)
             {
                 if (reply.Success)
-                    reply = new Parsed<T>(reply.Value, reply.Position, reply.EndOfInput, errors);
+                    reply = new Parsed<T>(reply.Value, reply.Position, errors);
                 else
-                    reply = new Error<T>(reply.Position, reply.EndOfInput, errors);
+                    reply = new Error<T>(reply.Position, errors);
             }
 
             return reply;

--- a/src/Parsley/Grammar.Label.cs
+++ b/src/Parsley/Grammar.Label.cs
@@ -15,7 +15,7 @@ partial class Grammar
         {
             var start = input.Position;
             var reply = parse(input);
-            var newPosition = reply.UnparsedInput.Position;
+            var newPosition = reply.Position;
 
             if (start == newPosition)
             {

--- a/src/Parsley/Grammar.Operator.cs
+++ b/src/Parsley/Grammar.Operator.cs
@@ -12,10 +12,10 @@ partial class Grammar
             {
                 input.Advance(peek.Length);
 
-                return new Parsed<string>(peek, input, input.Position, input.EndOfInput);
+                return new Parsed<string>(peek, input.Position, input.EndOfInput);
             }
 
-            return new Error<string>(input, input.Position, input.EndOfInput, ErrorMessage.Expected(symbol));
+            return new Error<string>(input.Position, input.EndOfInput, ErrorMessage.Expected(symbol));
         };
     }
 }

--- a/src/Parsley/Grammar.Operator.cs
+++ b/src/Parsley/Grammar.Operator.cs
@@ -10,9 +10,9 @@ partial class Grammar
 
             if (peek == symbol)
             {
-                var unparsedInput = input.Advance(peek.Length);
+                input.Advance(peek.Length);
 
-                return new Parsed<string>(peek, unparsedInput, unparsedInput.Position, unparsedInput.EndOfInput);
+                return new Parsed<string>(peek, input, input.Position, input.EndOfInput);
             }
 
             return new Error<string>(input, input.Position, input.EndOfInput, ErrorMessage.Expected(symbol));

--- a/src/Parsley/Grammar.Operator.cs
+++ b/src/Parsley/Grammar.Operator.cs
@@ -8,9 +8,14 @@ partial class Grammar
         {
             var peek = input.Peek(symbol.Length);
 
-            return peek == symbol
-                ? new Parsed<string>(peek, input.Advance(peek.Length))
-                : new Error<string>(input, ErrorMessage.Expected(symbol));
+            if (peek == symbol)
+            {
+                var unparsedInput = input.Advance(peek.Length);
+
+                return new Parsed<string>(peek, unparsedInput, unparsedInput.Position, unparsedInput.EndOfInput);
+            }
+
+            return new Error<string>(input, input.Position, input.EndOfInput, ErrorMessage.Expected(symbol));
         };
     }
 }

--- a/src/Parsley/Grammar.Operator.cs
+++ b/src/Parsley/Grammar.Operator.cs
@@ -12,10 +12,10 @@ partial class Grammar
             {
                 input.Advance(peek.Length);
 
-                return new Parsed<string>(peek, input.Position, input.EndOfInput);
+                return new Parsed<string>(peek, input.Position);
             }
 
-            return new Error<string>(input.Position, input.EndOfInput, ErrorMessage.Expected(symbol));
+            return new Error<string>(input.Position, ErrorMessage.Expected(symbol));
         };
     }
 }

--- a/src/Parsley/Grammar.Pattern.cs
+++ b/src/Parsley/Grammar.Pattern.cs
@@ -17,10 +17,10 @@ partial class Grammar
             {
                 input.Advance(match.Value.Length);
 
-                return new Parsed<string>(match.Value, input.Position, input.EndOfInput);
+                return new Parsed<string>(match.Value, input.Position);
             }
 
-            return new Error<string>(input.Position, input.EndOfInput, ErrorMessage.Expected(name));
+            return new Error<string>(input.Position, ErrorMessage.Expected(name));
         };
     }
 }

--- a/src/Parsley/Grammar.Pattern.cs
+++ b/src/Parsley/Grammar.Pattern.cs
@@ -17,10 +17,10 @@ partial class Grammar
             {
                 input.Advance(match.Value.Length);
 
-                return new Parsed<string>(match.Value, input, input.Position, input.EndOfInput);
+                return new Parsed<string>(match.Value, input.Position, input.EndOfInput);
             }
 
-            return new Error<string>(input, input.Position, input.EndOfInput, ErrorMessage.Expected(name));
+            return new Error<string>(input.Position, input.EndOfInput, ErrorMessage.Expected(name));
         };
     }
 }

--- a/src/Parsley/Grammar.Pattern.cs
+++ b/src/Parsley/Grammar.Pattern.cs
@@ -12,9 +12,15 @@ partial class Grammar
         {
             var match = input.Match(regex);
 
-            return match.Success
-                ? new Parsed<string>(match.Value, input.Advance(match.Value.Length))
-                : new Error<string>(input, ErrorMessage.Expected(name));
+
+            if (match.Success)
+            {
+                var unparsedInput = input.Advance(match.Value.Length);
+
+                return new Parsed<string>(match.Value, unparsedInput, unparsedInput.Position, unparsedInput.EndOfInput);
+            }
+
+            return new Error<string>(input, input.Position, input.EndOfInput, ErrorMessage.Expected(name));
         };
     }
 }

--- a/src/Parsley/Grammar.Pattern.cs
+++ b/src/Parsley/Grammar.Pattern.cs
@@ -15,9 +15,9 @@ partial class Grammar
 
             if (match.Success)
             {
-                var unparsedInput = input.Advance(match.Value.Length);
+                input.Advance(match.Value.Length);
 
-                return new Parsed<string>(match.Value, unparsedInput, unparsedInput.Position, unparsedInput.EndOfInput);
+                return new Parsed<string>(match.Value, input, input.Position, input.EndOfInput);
             }
 
             return new Error<string>(input, input.Position, input.EndOfInput, ErrorMessage.Expected(name));

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -25,16 +25,16 @@ partial class Grammar
 
                 list.Add(reply.Value);
                 oldPosition = newPosition;
-                reply = item(reply.UnparsedInput);
+                reply = item(input);
                 newPosition = reply.Position;
             }
 
             //The item parser finally failed.
 
             if (oldPosition != newPosition)
-                return new Error<IEnumerable<T>>(reply.UnparsedInput, reply.Position, reply.EndOfInput, reply.ErrorMessages);
+                return new Error<IEnumerable<T>>(reply.Position, reply.EndOfInput, reply.ErrorMessages);
 
-            return new Parsed<IEnumerable<T>>(list, reply.UnparsedInput, reply.Position, reply.EndOfInput, reply.ErrorMessages);
+            return new Parsed<IEnumerable<T>>(list, reply.Position, reply.EndOfInput, reply.ErrorMessages);
         };
     }
 

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -32,9 +32,9 @@ partial class Grammar
             //The item parser finally failed.
 
             if (oldPosition != newPosition)
-                return new Error<IEnumerable<T>>(reply.Position, reply.EndOfInput, reply.ErrorMessages);
+                return new Error<IEnumerable<T>>(reply.Position, reply.ErrorMessages);
 
-            return new Parsed<IEnumerable<T>>(list, reply.Position, reply.EndOfInput, reply.ErrorMessages);
+            return new Parsed<IEnumerable<T>>(list, reply.Position, reply.ErrorMessages);
         };
     }
 

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -32,9 +32,15 @@ partial class Grammar
             //The item parser finally failed.
 
             if (oldPosition != newPosition)
-                return new Error<IEnumerable<T>>(reply.UnparsedInput, reply.ErrorMessages);
+            {
+                Text unparsedInput = reply.UnparsedInput;
 
-            return new Parsed<IEnumerable<T>>(list, reply.UnparsedInput, reply.ErrorMessages);
+                return new Error<IEnumerable<T>>(unparsedInput, unparsedInput.Position, unparsedInput.EndOfInput, reply.ErrorMessages);
+            }
+
+            Text unparsedInput1 = reply.UnparsedInput;
+
+            return new Parsed<IEnumerable<T>>(list, unparsedInput1, unparsedInput1.Position, unparsedInput1.EndOfInput, reply.ErrorMessages);
         };
     }
 

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -14,7 +14,7 @@ partial class Grammar
         {
             var oldPosition = input.Position;
             var reply = item(input);
-            var newPosition = reply.UnparsedInput.Position;
+            var newPosition = reply.Position;
 
             var list = new List<T>();
 
@@ -26,7 +26,7 @@ partial class Grammar
                 list.Add(reply.Value);
                 oldPosition = newPosition;
                 reply = item(reply.UnparsedInput);
-                newPosition = reply.UnparsedInput.Position;
+                newPosition = reply.Position;
             }
 
             //The item parser finally failed.

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -32,15 +32,9 @@ partial class Grammar
             //The item parser finally failed.
 
             if (oldPosition != newPosition)
-            {
-                Text unparsedInput = reply.UnparsedInput;
+                return new Error<IEnumerable<T>>(reply.UnparsedInput, reply.Position, reply.EndOfInput, reply.ErrorMessages);
 
-                return new Error<IEnumerable<T>>(unparsedInput, unparsedInput.Position, unparsedInput.EndOfInput, reply.ErrorMessages);
-            }
-
-            Text unparsedInput1 = reply.UnparsedInput;
-
-            return new Parsed<IEnumerable<T>>(list, unparsedInput1, unparsedInput1.Position, unparsedInput1.EndOfInput, reply.ErrorMessages);
+            return new Parsed<IEnumerable<T>>(list, reply.UnparsedInput, reply.Position, reply.EndOfInput, reply.ErrorMessages);
         };
     }
 

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -14,7 +14,7 @@ partial class Grammar
         {
             var oldPosition = input.Position;
             var reply = item(input);
-            var newPosition = reply.Position;
+            var newPosition = input.Position;
 
             var list = new List<T>();
 
@@ -26,7 +26,7 @@ partial class Grammar
                 list.Add(reply.Value);
                 oldPosition = newPosition;
                 reply = item(input);
-                newPosition = reply.Position;
+                newPosition = input.Position;
             }
 
             //The item parser finally failed.

--- a/src/Parsley/OperatorPrecedenceParser.cs
+++ b/src/Parsley/OperatorPrecedenceParser.cs
@@ -65,7 +65,7 @@ public class OperatorPrecedenceParser<T>
         var matchingUnitParser = FirstMatchingUnitParserOrNull(input, out var token);
 
         if (matchingUnitParser == null)
-            return new Error<T>(input.Position, input.EndOfInput, ErrorMessage.Unknown());
+            return new Error<T>(input.Position, ErrorMessage.Unknown());
 
         var reply = matchingUnitParser(input);
 

--- a/src/Parsley/OperatorPrecedenceParser.cs
+++ b/src/Parsley/OperatorPrecedenceParser.cs
@@ -72,8 +72,6 @@ public class OperatorPrecedenceParser<T>
         if (!reply.Success)
             return reply;
 
-        input = reply.UnparsedInput;
-
         var matchingExtendParserBuilder = FirstMatchingExtendParserBuilderOrNull(input, out token, out int? tokenPrecedence);
 
         while (matchingExtendParserBuilder != null && precedence < tokenPrecedence)
@@ -86,8 +84,6 @@ public class OperatorPrecedenceParser<T>
 
             if (!reply.Success)
                 return reply;
-
-            input = reply.UnparsedInput;
 
             matchingExtendParserBuilder = FirstMatchingExtendParserBuilderOrNull(input, out token, out tokenPrecedence);
         }

--- a/src/Parsley/OperatorPrecedenceParser.cs
+++ b/src/Parsley/OperatorPrecedenceParser.cs
@@ -65,7 +65,7 @@ public class OperatorPrecedenceParser<T>
         var matchingUnitParser = FirstMatchingUnitParserOrNull(input, out var token);
 
         if (matchingUnitParser == null)
-            return new Error<T>(input, input.Position, input.EndOfInput, ErrorMessage.Unknown());
+            return new Error<T>(input.Position, input.EndOfInput, ErrorMessage.Unknown());
 
         var reply = matchingUnitParser(input);
 

--- a/src/Parsley/OperatorPrecedenceParser.cs
+++ b/src/Parsley/OperatorPrecedenceParser.cs
@@ -65,7 +65,7 @@ public class OperatorPrecedenceParser<T>
         var matchingUnitParser = FirstMatchingUnitParserOrNull(input, out var token);
 
         if (matchingUnitParser == null)
-            return new Error<T>(input, ErrorMessage.Unknown());
+            return new Error<T>(input, input.Position, input.EndOfInput, ErrorMessage.Unknown());
 
         var reply = matchingUnitParser(input);
 

--- a/src/Parsley/OperatorPrecedenceParser.cs
+++ b/src/Parsley/OperatorPrecedenceParser.cs
@@ -101,7 +101,9 @@ public class OperatorPrecedenceParser<T>
 
         foreach(var (kind, parser) in unitParsers)
         {
+            var snapshot = input.Snapshot();
             var reply = kind(input);
+            input.Restore(snapshot);
 
             if (reply.Success)
             {
@@ -120,7 +122,9 @@ public class OperatorPrecedenceParser<T>
 
         foreach (var (kind, precedence, extendParserBuilder) in extendParsers)
         {
+            var snapshot = input.Snapshot();
             var reply = kind(input);
+            input.Restore(snapshot);
 
             if (reply.Success)
             {

--- a/src/Parsley/Parsed.cs
+++ b/src/Parsley/Parsed.cs
@@ -2,15 +2,15 @@ namespace Parsley;
 
 public class Parsed<T> : Reply<T>
 {
-    public Parsed(T value, Text unparsedInput)
-        :this(value, unparsedInput, ErrorMessageList.Empty) { }
+    public Parsed(T value, Text unparsedInput, Position position, bool endOfInput)
+        :this(value, unparsedInput, position, endOfInput, ErrorMessageList.Empty) { }
 
-    public Parsed(T value, Text unparsedInput, ErrorMessageList potentialErrors)
+    public Parsed(T value, Text unparsedInput, Position position, bool endOfInput, ErrorMessageList potentialErrors)
     {
         Value = value;
         UnparsedInput = unparsedInput;
-        Position = unparsedInput.Position;
-        EndOfInput = unparsedInput.EndOfInput;
+        Position = position;
+        EndOfInput = endOfInput;
         ErrorMessages = potentialErrors;
     }
 

--- a/src/Parsley/Parsed.cs
+++ b/src/Parsley/Parsed.cs
@@ -2,20 +2,18 @@ namespace Parsley;
 
 public class Parsed<T> : Reply<T>
 {
-    public Parsed(T value, Text unparsedInput, Position position, bool endOfInput)
-        :this(value, unparsedInput, position, endOfInput, ErrorMessageList.Empty) { }
+    public Parsed(T value, Position position, bool endOfInput)
+        :this(value, position, endOfInput, ErrorMessageList.Empty) { }
 
-    public Parsed(T value, Text unparsedInput, Position position, bool endOfInput, ErrorMessageList potentialErrors)
+    public Parsed(T value, Position position, bool endOfInput, ErrorMessageList potentialErrors)
     {
         Value = value;
-        UnparsedInput = unparsedInput;
         Position = position;
         EndOfInput = endOfInput;
         ErrorMessages = potentialErrors;
     }
 
     public T Value { get; }
-    public Text UnparsedInput { get; }
     public Position Position { get; }
     public bool EndOfInput { get; }
     public bool Success => true;

--- a/src/Parsley/Parsed.cs
+++ b/src/Parsley/Parsed.cs
@@ -2,20 +2,18 @@ namespace Parsley;
 
 public class Parsed<T> : Reply<T>
 {
-    public Parsed(T value, Position position, bool endOfInput)
-        :this(value, position, endOfInput, ErrorMessageList.Empty) { }
+    public Parsed(T value, Position position)
+        :this(value, position, ErrorMessageList.Empty) { }
 
-    public Parsed(T value, Position position, bool endOfInput, ErrorMessageList potentialErrors)
+    public Parsed(T value, Position position, ErrorMessageList potentialErrors)
     {
         Value = value;
         Position = position;
-        EndOfInput = endOfInput;
         ErrorMessages = potentialErrors;
     }
 
     public T Value { get; }
     public Position Position { get; }
-    public bool EndOfInput { get; }
     public bool Success => true;
     public ErrorMessageList ErrorMessages { get; }
 }

--- a/src/Parsley/Parsed.cs
+++ b/src/Parsley/Parsed.cs
@@ -9,11 +9,15 @@ public class Parsed<T> : Reply<T>
     {
         Value = value;
         UnparsedInput = unparsedInput;
+        Position = unparsedInput.Position;
+        EndOfInput = unparsedInput.EndOfInput;
         ErrorMessages = potentialErrors;
     }
 
     public T Value { get; }
     public Text UnparsedInput { get; }
+    public Position Position { get; }
+    public bool EndOfInput { get; }
     public bool Success => true;
     public ErrorMessageList ErrorMessages { get; }
 }

--- a/src/Parsley/ParserQuery.cs
+++ b/src/Parsley/ParserQuery.cs
@@ -12,7 +12,7 @@ public static class ParserQuery
     /// <param name="value">The value to treat as a parse result.</param>
     public static Parser<T> SucceedWithThisValue<T>(this T value)
     {
-        return input => new Parsed<T>(value, input.Position, input.EndOfInput);
+        return input => new Parsed<T>(value, input.Position);
     }
 
     /// <summary>
@@ -46,7 +46,7 @@ public static class ParserQuery
             if (reply.Success)
                 return constructNextParser(reply.Value)(input);
 
-            return new Error<U>(reply.Position, reply.EndOfInput, reply.ErrorMessages);
+            return new Error<U>(reply.Position, reply.ErrorMessages);
         };
     }
 }

--- a/src/Parsley/ParserQuery.cs
+++ b/src/Parsley/ParserQuery.cs
@@ -46,9 +46,7 @@ public static class ParserQuery
             if (reply.Success)
                 return constructNextParser(reply.Value)(reply.UnparsedInput);
 
-            Text unparsedInput = reply.UnparsedInput;
-
-            return new Error<U>(unparsedInput, unparsedInput.Position, unparsedInput.EndOfInput, reply.ErrorMessages);
+            return new Error<U>(reply.UnparsedInput, reply.Position, reply.EndOfInput, reply.ErrorMessages);
         };
     }
 }

--- a/src/Parsley/ParserQuery.cs
+++ b/src/Parsley/ParserQuery.cs
@@ -12,7 +12,7 @@ public static class ParserQuery
     /// <param name="value">The value to treat as a parse result.</param>
     public static Parser<T> SucceedWithThisValue<T>(this T value)
     {
-        return input => new Parsed<T>(value, input, input.Position, input.EndOfInput);
+        return input => new Parsed<T>(value, input.Position, input.EndOfInput);
     }
 
     /// <summary>
@@ -44,9 +44,9 @@ public static class ParserQuery
             var reply = parse(input);
 
             if (reply.Success)
-                return constructNextParser(reply.Value)(reply.UnparsedInput);
+                return constructNextParser(reply.Value)(input);
 
-            return new Error<U>(reply.UnparsedInput, reply.Position, reply.EndOfInput, reply.ErrorMessages);
+            return new Error<U>(reply.Position, reply.EndOfInput, reply.ErrorMessages);
         };
     }
 }

--- a/src/Parsley/ParserQuery.cs
+++ b/src/Parsley/ParserQuery.cs
@@ -12,7 +12,7 @@ public static class ParserQuery
     /// <param name="value">The value to treat as a parse result.</param>
     public static Parser<T> SucceedWithThisValue<T>(this T value)
     {
-        return input => new Parsed<T>(value, input);
+        return input => new Parsed<T>(value, input, input.Position, input.EndOfInput);
     }
 
     /// <summary>
@@ -46,7 +46,9 @@ public static class ParserQuery
             if (reply.Success)
                 return constructNextParser(reply.Value)(reply.UnparsedInput);
 
-            return new Error<U>(reply.UnparsedInput, reply.ErrorMessages);
+            Text unparsedInput = reply.UnparsedInput;
+
+            return new Error<U>(unparsedInput, unparsedInput.Position, unparsedInput.EndOfInput, reply.ErrorMessages);
         };
     }
 }

--- a/src/Parsley/ParsingAssertions.cs
+++ b/src/Parsley/ParsingAssertions.cs
@@ -22,20 +22,7 @@ public static class ParsingAssertions
             throw new AssertionException(expected, actual.Value);
     }
 
-    public static Reply<T> FailsToParse<T>(this Parser<T> parse, string input)
-    {
-        var text = new Text(input);
-        var reply = parse(text);
-            
-        if (reply.Success)
-            throw new AssertionException("parser failure", "parser completed successfully");
-
-        text.AtEndOfInput();
-        
-        return reply;
-    }
-
-    public static Reply<T> FailsToParse<T>(this Parser<T> parse, string input, string expectedUnparsedInput)
+    public static Reply<T> FailsToParse<T>(this Parser<T> parse, string input, string expectedUnparsedInput, string expectedMessage)
     {
         var text = new Text(input);
         var reply = parse(text);
@@ -44,7 +31,12 @@ public static class ParsingAssertions
             throw new AssertionException("parser failure", "parser completed successfully");
 
         text.LeavingUnparsedInput(expectedUnparsedInput);
+        
+        if (expectedUnparsedInput == "")
+            text.AtEndOfInput();
 
+        reply.WithMessage(expectedMessage);
+        
         return reply;
     }
 

--- a/src/Parsley/ParsingAssertions.cs
+++ b/src/Parsley/ParsingAssertions.cs
@@ -48,7 +48,7 @@ public static class ParsingAssertions
 
     public static Reply<T> WithMessage<T>(this Reply<T> reply, string expectedMessage)
     {
-        var position = reply.UnparsedInput.Position;
+        var position = reply.Position;
         var actual = position + ": " + reply.ErrorMessages;
             
         if (actual != expectedMessage)
@@ -79,7 +79,7 @@ public static class ParsingAssertions
     {
         if (!reply.Success)
         {
-            var message = "Position: " + reply.UnparsedInput.Position
+            var message = "Position: " + reply.Position
                                        + Environment.NewLine
                                        + "Error Message: " + reply.ErrorMessages;
             throw new AssertionException(message, "parser success", "parser failed");
@@ -102,7 +102,7 @@ public static class ParsingAssertions
 
     public static Reply<T> AtEndOfInput<T>(this Reply<T> reply)
     {
-        if (!reply.UnparsedInput.EndOfInput)
+        if (!reply.EndOfInput)
             throw new AssertionException("end of input", reply.UnparsedInput);
 
         return reply.LeavingUnparsedInput("");

--- a/src/Parsley/ParsingAssertions.cs
+++ b/src/Parsley/ParsingAssertions.cs
@@ -24,24 +24,26 @@ public static class ParsingAssertions
 
     public static Reply<T> FailsToParse<T>(this Parser<T> parse, string input)
     {
-        var reply = parse(new Text(input));
+        var text = new Text(input);
+        var reply = parse(text);
             
         if (reply.Success)
             throw new AssertionException("parser failure", "parser completed successfully");
 
-        reply.AtEndOfInput();
+        text.AtEndOfInput();
         
         return reply;
     }
 
     public static Reply<T> FailsToParse<T>(this Parser<T> parse, string input, string expectedUnparsedInput)
     {
-        var reply = parse(new Text(input));
+        var text = new Text(input);
+        var reply = parse(text);
             
         if (reply.Success)
             throw new AssertionException("parser failure", "parser completed successfully");
 
-        reply.LeavingUnparsedInput(expectedUnparsedInput);
+        text.LeavingUnparsedInput(expectedUnparsedInput);
 
         return reply;
     }
@@ -67,12 +69,23 @@ public static class ParsingAssertions
 
     public static Reply<T> PartiallyParses<T>(this Parser<T> parse, string input, string expectedUnparsedInput)
     {
-        return parse(new Text(input)).Succeeds().LeavingUnparsedInput(expectedUnparsedInput);
+        var text = new Text(input);
+
+        var reply = parse(text).Succeeds();
+
+        text.LeavingUnparsedInput(expectedUnparsedInput);
+
+        return reply;
     }
 
     public static Reply<T> Parses<T>(this Parser<T> parse, string input)
     {
-        return parse(new Text(input)).Succeeds().AtEndOfInput();
+        var text = new Text(input);
+        var reply = parse(text).Succeeds();
+
+        text.AtEndOfInput();
+
+        return reply;
     }
 
     static Reply<T> Succeeds<T>(this Reply<T> reply)
@@ -88,24 +101,22 @@ public static class ParsingAssertions
         return reply;
     }
 
-    public static Reply<T> LeavingUnparsedInput<T>(this Reply<T> reply, string expectedUnparsedInput)
+    static void LeavingUnparsedInput(this Text text, string expectedUnparsedInput)
     {
-        var actualUnparsedInput = reply.UnparsedInput.ToString();
+        var actualUnparsedInput = text.ToString();
 
         if (actualUnparsedInput != expectedUnparsedInput)
             throw new AssertionException("Parse resulted in unexpected remaining unparsed input.",
                 expectedUnparsedInput,
                 actualUnparsedInput);
-
-        return reply;
     }
 
-    public static Reply<T> AtEndOfInput<T>(this Reply<T> reply)
+    static void AtEndOfInput(this Text text)
     {
-        if (!reply.EndOfInput)
-            throw new AssertionException("end of input", reply.UnparsedInput);
+        if (!text.EndOfInput)
+            throw new AssertionException("end of input", text.ToString());
 
-        return reply.LeavingUnparsedInput("");
+        text.LeavingUnparsedInput("");
     }
 
     public static Reply<T> WithValue<T>(this Reply<T> reply, T expected)

--- a/src/Parsley/Reply.cs
+++ b/src/Parsley/Reply.cs
@@ -4,6 +4,8 @@ public interface Reply<out T>
 {
     T Value { get; }
     Text UnparsedInput { get; }
+    Position Position { get; }
+    bool EndOfInput { get; }
     bool Success { get; }
     ErrorMessageList ErrorMessages { get; }
 }

--- a/src/Parsley/Reply.cs
+++ b/src/Parsley/Reply.cs
@@ -3,7 +3,6 @@ namespace Parsley;
 public interface Reply<out T>
 {
     T Value { get; }
-    Text UnparsedInput { get; }
     Position Position { get; }
     bool EndOfInput { get; }
     bool Success { get; }

--- a/src/Parsley/Reply.cs
+++ b/src/Parsley/Reply.cs
@@ -4,7 +4,6 @@ public interface Reply<out T>
 {
     T Value { get; }
     Position Position { get; }
-    bool EndOfInput { get; }
     bool Success { get; }
     ErrorMessageList ErrorMessages { get; }
 }

--- a/src/Parsley/Text.cs
+++ b/src/Parsley/Text.cs
@@ -2,9 +2,9 @@ namespace Parsley;
 
 public class Text
 {
-    readonly int index;
+    int index;
     readonly string input;
-    readonly int line;
+    int line;
 
     public Text(string input)
         : this(input, 0, 1) { }
@@ -25,15 +25,19 @@ public class Text
             ? input.Substring(index)
             : input.Substring(index, characters);
 
-    public Text Advance(int characters)
+    public void Advance(int characters)
     {
         if (characters == 0)
-            return this;
+            return;
 
         int newIndex = index + characters;
         int newLineNumber = line + Peek(characters).Cast<char>().Count(ch => ch == '\n');
-            
-        return new Text(input, newIndex, newLineNumber);
+
+        index = newIndex;
+        line = newLineNumber;
+
+        if (index > input.Length)
+            index = input.Length;
     }
 
     public bool EndOfInput => index >= input.Length;
@@ -69,6 +73,15 @@ public class Text
 
     public Position Position
         => new(line, Column);
+
+    public (int index, int line) Snapshot()
+        => (index, line);
+
+    public void Restore((int index, int line) snapshot)
+    {
+        index = snapshot.index;
+        line = snapshot.line;
+    }
 
     public override string ToString()
         => input.Substring(index);


### PR DESCRIPTION
This simplifies the tracking of progress through the input string, phasing out noise in the `Reply<T>` types and dramatically reducing the number of wasteful allocations made with each step through the input.

Before this, `Text` was an immutable wrapper of the original string and current position, with some line ending awareness to generate useful `Position` values (line, column). Here, `Text` becomes mutable with a minimum of backtracking support. Since it is mutable, we no longer have to play the Haskell-like "pass along the *rest* of the input to each step in the parsing" game.