### PR TITLE
Enable nullable reference types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -34,10 +34,22 @@ resharper_space_within_single_line_array_initializer_braces = true
 resharper_wrap_before_arrow_with_expressions = true
 resharper_wrap_before_first_type_parameter_constraint = true
 
+# Diagnostic Severity - See https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/categories
 dotnet_analyzer_diagnostic.severity = error
-dotnet_analyzer_diagnostic.category-Style.severity = default
 dotnet_analyzer_diagnostic.category-Design.severity = default
+dotnet_analyzer_diagnostic.category-Documentation.severity = error
+dotnet_analyzer_diagnostic.category-Globalization.severity = error
+dotnet_analyzer_diagnostic.category-Interoperability.severity = error
+dotnet_analyzer_diagnostic.category-Maintainability.severity = error
 dotnet_analyzer_diagnostic.category-Naming.severity = default
+dotnet_analyzer_diagnostic.category-Performance.severity = error
+dotnet_analyzer_diagnostic.category-SingleFile.severity = error
+dotnet_analyzer_diagnostic.category-Reliability.severity = error
+dotnet_analyzer_diagnostic.category-Security.severity = error
+dotnet_analyzer_diagnostic.category-Style.severity = default
+dotnet_analyzer_diagnostic.category-Usage.severity = error
+dotnet_analyzer_diagnostic.category-CodeQuality.severity = error
+
 dotnet_diagnostic.CS0612.severity = warning # '...' is obsolete
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member '...'
 dotnet_diagnostic.CS0162.severity = warning # Unreachable code detected

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -122,9 +122,7 @@ class GrammarTests
 
     public void ParsingAnOptionalRuleZeroOrOneTimes()
     {
-        var charOrNull = Optional(Character(x => true, "Any Character"));
-
-        //Reference Type to Reference Type
+        //Reference Type to Nullable Reference Type
         Optional(AB).PartiallyParses("AB.", ".").WithValue("AB");
         Optional(AB).PartiallyParses(".", ".").WithValue((string?)null);
         Optional(AB).FailsToParse("AC.", "C.", "(1, 2): B expected");
@@ -135,10 +133,15 @@ class GrammarTests
         Optional(B).PartiallyParses("A", "A").WithValue((char?)null);
         Optional(B).PartiallyParses("", "").WithValue((char?)null);
 
-        //Nullable Value Type to Nullable Value Type
-        Optional(charOrNull).PartiallyParses("AB.", "B.").WithValue('A');
-        Optional(charOrNull).PartiallyParses(".", "").WithValue('.');
-        Optional(charOrNull).PartiallyParses("", "").WithValue((char?)null);
+        //Alternate possibilities are not supported when nullable
+        //reference types are enabled:
+        //
+        //  Nullable Reference Type to Nullable Reference Type
+        //  Nullable Value Type to Nullable Value Type
+        //
+        //These are not supported because these use cases arise
+        //from the construction Optional(Optional(...)), which is
+        //suspect to begin with.
     }
 
     public void AttemptingToParseRuleButBacktrackingUponFailure()

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -123,9 +123,23 @@ class GrammarTests
 
     public void ParsingAnOptionalRuleZeroOrOneTimes()
     {
+        var charOrDefault = Optional(Character(x => true, "Any Character"));
+
+        //Reference Type to Reference Type
         Optional(AB).PartiallyParses("AB.", ".").WithValue("AB");
         Optional(AB).PartiallyParses(".", ".").WithValue((string)null);
         Optional(AB).FailsToParse("AC.", "C.", "(1, 2): B expected");
+
+        //Characterization coverage in anticipation of: Value Type to Nullable Value Type
+        Optional(A).PartiallyParses("AB.", "B.").WithValue('A');
+        Optional(A).PartiallyParses(".", ".").WithValue(default(char));
+        Optional(B).PartiallyParses("A", "A").WithValue(default(char));
+        Optional(B).PartiallyParses("", "").WithValue(default(char));
+
+        //Characterization coverage in anticipation of: Nullable Value Type to Nullable Value Type
+        Optional(charOrDefault).PartiallyParses("AB.", "B.").WithValue('A');
+        Optional(charOrDefault).PartiallyParses(".", "").WithValue('.');
+        Optional(charOrDefault).PartiallyParses("", "").WithValue(default(char));
     }
 
     public void AttemptingToParseRuleButBacktrackingUponFailure()

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using static Parsley.Grammar;
 
 namespace Parsley.Tests;

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -67,7 +67,7 @@ class GrammarTests
 
         parser.FailsToParse("ABABA!", "!", "(1, 6): B expected");
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input.Position);
+        Parser<string> succeedWithoutConsuming = input => new Parsed<string>("ignored value", input.Position);
         Action infiniteLoop = () => ZeroOrMore(succeedWithoutConsuming)(new Text(""));
 
         infiniteLoop
@@ -89,7 +89,7 @@ class GrammarTests
 
         parser.FailsToParse("ABABA!", "!", "(1, 6): B expected");
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input.Position);
+        Parser<string> succeedWithoutConsuming = input => new Parsed<string>("ignored value", input.Position);
         Action infiniteLoop = () => OneOrMore(succeedWithoutConsuming)(new Text(""));
 
         infiniteLoop
@@ -346,10 +346,10 @@ public class AlternationTests
     public void MergesPotentialErrorMessagesWhenParserSucceedsWithoutConsumingInput()
     {
         //Choice really shouldn't be used with parsers that can succeed without
-        //consuming input.  These tests simply describe the behavior under that
+        //consuming input. These tests simply describe the behavior under that
         //unusual situation.
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>(null, input.Position);
+        Parser<string> succeedWithoutConsuming = input => new Parsed<string>("ignored value", input.Position);
 
         var reply = Choice(A, succeedWithoutConsuming).Parses("");
         reply.ErrorMessages.ToString().ShouldBe("A expected");

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using static Parsley.Grammar;
 
 namespace Parsley.Tests;
@@ -123,23 +122,23 @@ class GrammarTests
 
     public void ParsingAnOptionalRuleZeroOrOneTimes()
     {
-        var charOrDefault = Optional(Character(x => true, "Any Character"));
+        var charOrNull = Optional(Character(x => true, "Any Character"));
 
         //Reference Type to Reference Type
         Optional(AB).PartiallyParses("AB.", ".").WithValue("AB");
-        Optional(AB).PartiallyParses(".", ".").WithValue((string)null);
+        Optional(AB).PartiallyParses(".", ".").WithValue((string?)null);
         Optional(AB).FailsToParse("AC.", "C.", "(1, 2): B expected");
 
-        //Characterization coverage in anticipation of: Value Type to Nullable Value Type
+        //Value Type to Nullable Value Type
         Optional(A).PartiallyParses("AB.", "B.").WithValue('A');
-        Optional(A).PartiallyParses(".", ".").WithValue(default(char));
-        Optional(B).PartiallyParses("A", "A").WithValue(default(char));
-        Optional(B).PartiallyParses("", "").WithValue(default(char));
+        Optional(A).PartiallyParses(".", ".").WithValue((char?)null);
+        Optional(B).PartiallyParses("A", "A").WithValue((char?)null);
+        Optional(B).PartiallyParses("", "").WithValue((char?)null);
 
-        //Characterization coverage in anticipation of: Nullable Value Type to Nullable Value Type
-        Optional(charOrDefault).PartiallyParses("AB.", "B.").WithValue('A');
-        Optional(charOrDefault).PartiallyParses(".", "").WithValue('.');
-        Optional(charOrDefault).PartiallyParses("", "").WithValue(default(char));
+        //Nullable Value Type to Nullable Value Type
+        Optional(charOrNull).PartiallyParses("AB.", "B.").WithValue('A');
+        Optional(charOrNull).PartiallyParses(".", "").WithValue('.');
+        Optional(charOrNull).PartiallyParses("", "").WithValue((char?)null);
     }
 
     public void AttemptingToParseRuleButBacktrackingUponFailure()

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Globalization;
 using static Parsley.Grammar;
 
@@ -6,10 +5,10 @@ namespace Parsley.Tests.IntegrationTests.Json;
 
 public class JsonGrammar
 {
-    public static readonly Parser<object> JsonDocument;
+    public static readonly Parser<object?> JsonDocument;
 
-    static readonly Parser<object> Value;
-
+    static readonly Parser<object?> Value = default!;
+    
     static JsonGrammar()
     {
         var Whitespace = Optional(OneOrMore(char.IsWhiteSpace, "whitespace"));
@@ -36,7 +35,7 @@ public class JsonGrammar
                 select (object) false,
 
                 from @null in Keyword("null")
-                select (object) null,
+                select (object?) null,
 
                 from number in Number
                 select (object) decimal.Parse(number, NumberStyles.Any, CultureInfo.InvariantCulture),

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System.Globalization;
 using static Parsley.Grammar;
 

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammarTests.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammarTests.cs
@@ -1,4 +1,3 @@
-#nullable disable
 namespace Parsley.Tests.IntegrationTests.Json;
 
 using static JsonGrammar;
@@ -17,7 +16,7 @@ class JsonGrammarTests
 
     public void ParsesNullLiteral()
     {
-        JsonDocument.Parses("null").WithValue((object)null);
+        JsonDocument.Parses("null").WithValue((object?)null);
     }
 
     public void ParsesNumbers()
@@ -51,7 +50,12 @@ class JsonGrammarTests
         var empty = "[]";
         var filled = "[0, 1, 2]";
 
-        JsonDocument.Parses(empty).WithValue(value => ((object[])value).ShouldBeEmpty());
+        JsonDocument.Parses(empty).WithValue(value =>
+        {
+            value.ShouldNotBeNull();
+
+            ((object[]) value).ShouldBeEmpty();
+        });
 
         JsonDocument.Parses(filled).WithValue(value => value.ShouldBe(new[] { 0m, 1m, 2m }));
     }
@@ -61,10 +65,17 @@ class JsonGrammarTests
         var empty = "{}";
         var filled = "{\"zero\" : 0, \"one\" : 1, \"two\" : 2}";
 
-        JsonDocument.Parses(empty).WithValue(value => ((Dictionary<string, object>)value).Count.ShouldBe(0));
+        JsonDocument.Parses(empty).WithValue(value =>
+        {
+            value.ShouldNotBeNull();
+
+            ((Dictionary<string, object>) value).Count.ShouldBe(0);
+        });
 
         JsonDocument.Parses(filled).WithValue(value =>
         {
+            value.ShouldNotBeNull();
+
             var dictionary = (Dictionary<string, object>) value;
             dictionary["zero"].ShouldBe(0m);
             dictionary["one"].ShouldBe(1m);
@@ -92,6 +103,8 @@ class JsonGrammarTests
 
         JsonDocument.Parses(complex).WithValue(value =>
         {
+            value.ShouldNotBeNull();
+
             var json = (Dictionary<string, object>)value;
             json["numbers"].ShouldBe(new[] {10m, 20m, 30m});
 

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammarTests.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammarTests.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Parsley.Tests.IntegrationTests.Json;
 
 using static JsonGrammar;

--- a/src/Parsley.Tests/Parsley.Tests.csproj
+++ b/src/Parsley.Tests/Parsley.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- <Nullable>enable</Nullable> -->
+    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Parsley.Tests/Parsley.Tests.csproj
+++ b/src/Parsley.Tests/Parsley.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <!-- <Nullable>enable</Nullable> -->
+    <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Parsley/ErrorMessageList.cs
+++ b/src/Parsley/ErrorMessageList.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Parsley;
 
 public class ErrorMessageList

--- a/src/Parsley/ErrorMessageList.cs
+++ b/src/Parsley/ErrorMessageList.cs
@@ -1,12 +1,11 @@
-#nullable disable
 namespace Parsley;
 
 public class ErrorMessageList
 {
     public static readonly ErrorMessageList Empty = new();
 
-    readonly ErrorMessage head;
-    readonly ErrorMessageList tail;
+    readonly ErrorMessage? head;
+    readonly ErrorMessageList? tail;
 
     ErrorMessageList()
     {
@@ -77,12 +76,11 @@ public class ErrorMessageList
 
     IEnumerable<T> All<T>() where T : ErrorMessage
     {
-        if (this != Empty)
-        {
-            if (head is T match)
-                yield return match;
+        if (head is T match)
+            yield return match;
+
+        if (tail != null)
             foreach (var message in tail.All<T>())
                 yield return message;
-        }
     }
 }

--- a/src/Parsley/Grammar.Optional.cs
+++ b/src/Parsley/Grammar.Optional.cs
@@ -1,4 +1,5 @@
-#nullable disable
+using System.Diagnostics.CodeAnalysis;
+
 namespace Parsley;
 
 public static partial class Grammar
@@ -7,9 +8,41 @@ public static partial class Grammar
     /// Optional(p) is equivalent to p whenever p succeeds or when p fails after consuming input.
     /// If p fails without consuming input, Optional(p) succeeds.
     /// </summary>
-    public static Parser<T> Optional<T>(Parser<T> parser)
+    public static Parser<T?> Optional<T>(Parser<T> parser)
+        where T : class
     {
         var nothing = default(T).SucceedWithThisValue();
         return Choice(parser, nothing);
+    }
+
+    /// <summary>
+    /// Optional(p) is equivalent to p whenever p succeeds or when p fails after consuming input.
+    /// If p fails without consuming input, Optional(p) succeeds.
+    ///
+    /// Use this overload when p produces nullable value type T?. In this case, the resulting
+    /// parser Optional(p) likewise produces nullable value type T?
+    /// </summary>
+    public static Parser<T?> Optional<T>(Parser<T?> parser)
+        where T : struct
+    {
+        var nothing = default(T?).SucceedWithThisValue();
+        return Choice(parser, nothing);
+    }
+
+    /// <summary>
+    /// Optional(p) is equivalent to p whenever p succeeds or when p fails after consuming input.
+    /// If p fails without consuming input, Optional(p) succeeds.
+    ///
+    /// Use this overload when p produces non-nullable value type T. In this case, the resulting
+    /// parser Optional(p) produces nullable value type T?, null when p has not succeeded.
+    /// </summary>
+    [SuppressMessage("ReSharper", "MethodOverloadWithOptionalParameter",
+        Justification = "This warning is inaccurate. The other `struct` " +
+                        "overload does not in fact hide this one.")]
+    public static Parser<T?> Optional<T>(Parser<T> parser, T? ignoredOverloadResolver = null)
+        where T : struct
+    {
+        var nothing = default(T?).SucceedWithThisValue();
+        return Choice(parser.Select(x => (T?)x), nothing);
     }
 }

--- a/src/Parsley/Grammar.Optional.cs
+++ b/src/Parsley/Grammar.Optional.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Parsley;
 
 public static partial class Grammar

--- a/src/Parsley/Grammar.Optional.cs
+++ b/src/Parsley/Grammar.Optional.cs
@@ -18,23 +18,6 @@ public static partial class Grammar
     /// <summary>
     /// Optional(p) is equivalent to p whenever p succeeds or when p fails after consuming input.
     /// If p fails without consuming input, Optional(p) succeeds.
-    ///
-    /// Use this overload when p produces nullable value type T?. In this case, the resulting
-    /// parser Optional(p) likewise produces nullable value type T?
-    /// </summary>
-    public static Parser<T?> Optional<T>(Parser<T?> parser)
-        where T : struct
-    {
-        var nothing = default(T?).SucceedWithThisValue();
-        return Choice(parser, nothing);
-    }
-
-    /// <summary>
-    /// Optional(p) is equivalent to p whenever p succeeds or when p fails after consuming input.
-    /// If p fails without consuming input, Optional(p) succeeds.
-    ///
-    /// Use this overload when p produces non-nullable value type T. In this case, the resulting
-    /// parser Optional(p) produces nullable value type T?, null when p has not succeeded.
     /// </summary>
     [SuppressMessage("ReSharper", "MethodOverloadWithOptionalParameter",
         Justification = "This warning is inaccurate. The other `struct` " +

--- a/src/Parsley/OperatorPrecedenceParser.cs
+++ b/src/Parsley/OperatorPrecedenceParser.cs
@@ -63,9 +63,7 @@ public class OperatorPrecedenceParser<T>
 
     Reply<T> Parse(Text input, int precedence)
     {
-        var matchingUnitParser = FirstMatchingUnitParserOrNull(input, out var token);
-
-        if (matchingUnitParser == null)
+        if (!TryFindMatchingUnitParser(input, out var matchingUnitParser, out var token))
             return new Error<T>(input.Position, ErrorMessage.Unknown());
 
         var reply = matchingUnitParser(input);
@@ -73,9 +71,7 @@ public class OperatorPrecedenceParser<T>
         if (!reply.Success)
             return reply;
 
-        var matchingExtendParserBuilder = FirstMatchingExtendParserBuilderOrNull(input, out token, out int? tokenPrecedence);
-
-        while (matchingExtendParserBuilder != null && precedence < tokenPrecedence)
+        while (TryFindMatchingExtendParserBuilder(input, out var matchingExtendParserBuilder, out token, out int? tokenPrecedence) && precedence < tokenPrecedence)
         {
             //Continue parsing at this precedence level.
 
@@ -85,15 +81,14 @@ public class OperatorPrecedenceParser<T>
 
             if (!reply.Success)
                 return reply;
-
-            matchingExtendParserBuilder = FirstMatchingExtendParserBuilderOrNull(input, out token, out tokenPrecedence);
         }
 
         return reply;
     }
 
-    Parser<T> FirstMatchingUnitParserOrNull(Text input, out string token)
+    bool TryFindMatchingUnitParser(Text input, out Parser<T> found, out string token)
     {
+        found = null;
         token = null;
 
         foreach(var (kind, parser) in unitParsers)
@@ -105,15 +100,17 @@ public class OperatorPrecedenceParser<T>
             if (reply.Success)
             {
                 token = reply.Value;
-                return parser;
+                found = parser;
+                return true;
             }
         }
 
-        return null;
+        return false;
     }
 
-    ExtendParserBuilder<T> FirstMatchingExtendParserBuilderOrNull(Text input, out string token, out int? tokenPrecedence)
+    bool TryFindMatchingExtendParserBuilder(Text input, out ExtendParserBuilder<T> found, out string token, out int? tokenPrecedence)
     {
+        found = null;
         token = null;
         tokenPrecedence = null;
 
@@ -127,10 +124,11 @@ public class OperatorPrecedenceParser<T>
             {
                 token = reply.Value;
                 tokenPrecedence = precedence;
-                return extendParserBuilder;
+                found = extendParserBuilder;
+                return true;
             }
         }
 
-        return null;
+        return false;
     }
 }

--- a/src/Parsley/OperatorPrecedenceParser.cs
+++ b/src/Parsley/OperatorPrecedenceParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Parsley;
 
 public delegate Parser<T> ExtendParserBuilder<T>(T left);

--- a/src/Parsley/OperatorPrecedenceParser.cs
+++ b/src/Parsley/OperatorPrecedenceParser.cs
@@ -1,4 +1,5 @@
-#nullable disable
+using System.Diagnostics.CodeAnalysis;
+
 namespace Parsley;
 
 public delegate Parser<T> ExtendParserBuilder<T>(T left);
@@ -86,7 +87,7 @@ public class OperatorPrecedenceParser<T>
         return reply;
     }
 
-    bool TryFindMatchingUnitParser(Text input, out Parser<T> found, out string token)
+    bool TryFindMatchingUnitParser(Text input, [NotNullWhen(true)] out Parser<T>? found, out string? token)
     {
         found = null;
         token = null;
@@ -108,7 +109,7 @@ public class OperatorPrecedenceParser<T>
         return false;
     }
 
-    bool TryFindMatchingExtendParserBuilder(Text input, out ExtendParserBuilder<T> found, out string token, out int? tokenPrecedence)
+    bool TryFindMatchingExtendParserBuilder(Text input, [NotNullWhen(true)] out ExtendParserBuilder<T>? found, out string? token, out int? tokenPrecedence)
     {
         found = null;
         token = null;

--- a/src/Parsley/Parsley.csproj
+++ b/src/Parsley/Parsley.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- <Nullable>enable</Nullable> -->
+    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Parsley/Parsley.csproj
+++ b/src/Parsley/Parsley.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <!-- <Nullable>enable</Nullable> -->
+    <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 


### PR DESCRIPTION
This enables the Nullable Reference Types C# feature solution-wide. To avoid falling into the easy trap of satisfying the compiler by blindly placing `?` everywhere, and having that propagate everywhere, the presence and impact of nulls were limited as much as possible with the following technique:

* Configure to treat nullable warnings as errors.
* Enable the Nullable Reference Types feature solution-wide via the csproj, but immediately place `#nullable disable` on the few code files with errors in that moment. This gives a clear punch list to address during the rest of the branch.
* Repeatedly identify the most containable examples of possible nulls, remove `#nullable` for that file, and address the errors while attempting to limit the propagation of nulls as much as possible.
* Once the last `#nullable disable` was removed and addressed, the work was complete.

Overall:

1. Nullability within `ErrorMessageList` was entirely contained within that class's private members. It was already null safe, but is now explicit and verifiable as null safe.
2. Nullability within `OperatorPrecedenceParser` was entirely contained wihtin that class's private members. It was already null safe, but has been rephrased with the `Try(out)` pattern so and marked with attrbutes so that it is verifiable as null safe.
3. The `Optional(...)` parser combinator was originally deficient when the original parser being modified was a `Parser<T>` for some *value type* `T`. Consumers could recieve `default(T)` as their overall result without being able to distinguish whether it is a *parsed, meaningful* value or instead a placeholder non-value when no input was consumed. This deficiency was not obvious until Nullable Reference Types were enabled, though it could have been found and fixed earlier. The fix was to supply overloads of `Optional<T>`, one for reference types and one for value types:

  * Reference Type to Nullable Reference Type: When parser `p` produces a reference type like `string`, parser `Optional(p)` produces the nullable version `string?`.
  * Value Type to Nullable Value Type: When parser `p` produces a value type like `char`, parser `Optional(p)` produces the nullable version `char?`.

Technically, you cannot simply overload a method on type constraints (`where T: class` vs `where T: struct`), but there is a workaround in play here so that for all practical pursposes the method *is* overloaded on those constraints: all calls to either method are in fact unambiguous to the compiler due to the inclusion of an extra, never used, default parameter on the struct overload:

```
    public static Parser<T?> Optional<T>(Parser<T> parser)
        where T : class
    {
        ...
    }

    public static Parser<T?> Optional<T>(Parser<T> parser, T? ignoredOverloadResolver = null)
        where T : struct
    {
        ...
    }
```

That extra unused argument provides the compiler enough information to make each invocation unambiguous. Without it, the compiler would complain *far before* the call sites get evaluated, complaining simply about the signature being identical. With it, we can get beyond the signature check and give the compiler a chance to evaluate each call site. While it evaluates the call sites, it knows whether the type in question is a value type or reference type and so unambiguously verifies each call even though the extra argument is never really specified by the developer (technically, the call site *does* include the value as the compiler "copies and pastes" the default to the call site early in compilation, but we can ignore that).

ReSharper mistakenly warns that the extra argument is "hidden by an overload", although ReSharper does accurately know which call sites are truly usages of each overload. The single occurrence of that warning is disabled with a justification string.

Although it would be *possible* to provide 2 more overloads (Nullable Reference Type to Nullable Reference Type, Nullable Value Type to Nullable Value Type), those are deliberately omitted. They correspond with the *highly suspect* construction Optional(Optional(...)). By omitting the overloads, the suspect usage produces a compiler error, protecting the end user from the attempting it.