### PR TITLE
Peek(int characters) returns `ReadOnlySpan<char>` instead of `string`.

### DIFF
--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -4,12 +4,20 @@ namespace Parsley.Tests;
 
 class ParserQueryTests
 {
-    static readonly Parser<string> Next = input =>
+    static readonly Parser<char> Next = input =>
     {
         var next = input.Peek(1);
-        input.Advance(1);
 
-        return new Parsed<string>(next, input.Position);
+        if (next.Length == 1)
+        {
+            char c = next[0];
+
+            input.Advance(1);
+
+            return new Parsed<char>(c, input.Position);
+        }
+
+        return new Error<char>(input.Position, ErrorMessage.Expected("character"));
     };
 
     public void CanBuildParserWhichSimulatesSuccessfulParsingOfGivenValueWithoutConsumingInput()
@@ -22,9 +30,9 @@ class ParserQueryTests
     public void CanBuildParserFromSingleSimplerParser()
     {
         var parser = from x in Next
-            select x.ToUpper(CultureInfo.InvariantCulture);
+            select char.ToUpper(x, CultureInfo.InvariantCulture);
 
-        parser.PartiallyParses("xy", "y").Value.ShouldBe("X");
+        parser.PartiallyParses("xy", "y").Value.ShouldBe('X');
     }
 
     public void CanBuildParserFromOrderedSequenceOfSimplerParsers()
@@ -32,7 +40,7 @@ class ParserQueryTests
         var parser = (from a in Next
             from b in Next
             from c in Next
-            select (a + b + c).ToUpper(CultureInfo.InvariantCulture));
+            select $"{a}{b}{c}".ToUpper(CultureInfo.InvariantCulture));
 
         parser.PartiallyParses("abcdef", "def").Value.ShouldBe("ABC");
     }

--- a/src/Parsley.Tests/TextTests.cs
+++ b/src/Parsley.Tests/TextTests.cs
@@ -7,16 +7,16 @@ class TextTests
     public void CanPeekAheadNCharacters()
     {
         var empty = new Text("");
-        empty.Peek(0).ShouldBe("");
-        empty.Peek(1).ShouldBe("");
+        empty.Peek(0).ToString().ShouldBe("");
+        empty.Peek(1).ToString().ShouldBe("");
 
         var abc = new Text("abc");
-        abc.Peek(0).ShouldBe("");
-        abc.Peek(1).ShouldBe("a");
-        abc.Peek(2).ShouldBe("ab");
-        abc.Peek(3).ShouldBe("abc");
-        abc.Peek(4).ShouldBe("abc");
-        abc.Peek(100).ShouldBe("abc");
+        abc.Peek(0).ToString().ShouldBe("");
+        abc.Peek(1).ToString().ShouldBe("a");
+        abc.Peek(2).ToString().ShouldBe("ab");
+        abc.Peek(3).ToString().ShouldBe("abc");
+        abc.Peek(4).ToString().ShouldBe("abc");
+        abc.Peek(100).ToString().ShouldBe("abc");
     }
 
     public void CanAdvanceAheadNCharactersWithSnapshotBacktracking()

--- a/src/Parsley/Grammar.Keyword.cs
+++ b/src/Parsley/Grammar.Keyword.cs
@@ -11,7 +11,7 @@ partial class Grammar
         {
             var peek = input.Peek(word.Length + 1);
 
-            if (peek.StartsWith(word, StringComparison.Ordinal))
+            if (peek.StartsWith(word))
             {
                 if (peek.Length == word.Length || !char.IsLetter(peek[^1]))
                 {

--- a/src/Parsley/Grammar.Operator.cs
+++ b/src/Parsley/Grammar.Operator.cs
@@ -10,9 +10,9 @@ partial class Grammar
 
             if (peek == symbol)
             {
-                input.Advance(peek.Length);
+                input.Advance(symbol.Length);
 
-                return new Parsed<string>(peek, input.Position);
+                return new Parsed<string>(symbol, input.Position);
             }
 
             return new Error<string>(input.Position, ErrorMessage.Expected(symbol));

--- a/src/Parsley/Grammar.Operator.cs
+++ b/src/Parsley/Grammar.Operator.cs
@@ -8,7 +8,7 @@ partial class Grammar
         {
             var peek = input.Peek(symbol.Length);
 
-            if (peek == symbol)
+            if (peek.Equals(symbol, StringComparison.Ordinal))
             {
                 input.Advance(symbol.Length);
 

--- a/src/Parsley/Text.cs
+++ b/src/Parsley/Text.cs
@@ -20,7 +20,7 @@ public class Text
         this.line = line;
     }
 
-    public string Peek(int characters)
+    public ReadOnlySpan<char> Peek(int characters)
         => index + characters >= input.Length
             ? input.Substring(index)
             : input.Substring(index, characters);
@@ -55,7 +55,7 @@ public class Text
         while (i < input.Length && test(input[i]))
             i++;
 
-        value = Peek(i - index);
+        value = Peek(i - index).ToString();
 
         return value.Length > 0;
     }

--- a/src/Parsley/Text.cs
+++ b/src/Parsley/Text.cs
@@ -31,7 +31,13 @@ public class Text
             return;
 
         int newIndex = index + characters;
-        int newLineNumber = line + Peek(characters).Cast<char>().Count(ch => ch == '\n');
+        int countNewLines = 0;
+
+        foreach (var ch in Peek(characters))
+            if (ch == '\n')
+                countNewLines++;
+
+        int newLineNumber = line + countNewLines;
 
         index = newIndex;
         line = newLineNumber;

--- a/src/Parsley/Text.cs
+++ b/src/Parsley/Text.cs
@@ -22,8 +22,8 @@ public class Text
 
     public ReadOnlySpan<char> Peek(int characters)
         => index + characters >= input.Length
-            ? input.Substring(index)
-            : input.Substring(index, characters);
+            ? input.AsSpan().Slice(index)
+            : input.AsSpan().Slice(index, characters);
 
     public void Advance(int characters)
     {


### PR DESCRIPTION
The PR which *follows* this one will improve all traversal through the input string by converting the `Text` string-wrapper into a stack-only `ref struct` and replacing the many `Substring` operations with equivalent but more efficient `Slice` operations.

As the changes for that PR will be sufficiently large on their own, it helps to "get our feet wet" with spans by first nudging the `Text.Peek(int characters)` method to work with spans. This change is a prerequisite for the larger transformation, but is at least safe to perform here in isolation.

While it's tempting to just aggressively alter the `Peek(int)` method's return type and then chase compiler errors from there, here the commit history shows a safer approach. Knowing what compiler errors *would* have occurred, we "get ahead" of them one at a time by performing changes that would be sound on their own. By the time it gets to the commit that actually alters the return type, there's very little work to actually do. This kept the system building and passing tests throughout developerment, which is particularly helpful here as there are *many* subtle restrictions enforced on spans by the compiler.

Having `Peek(int)` return a span is a *suggestion* that we're building up to a dramatic performance enhancement around memory allocations, but this PR alone does not actually move the needle *much*: we're still working with a string field to begin with, so we repeatedly have to convert this to a span each time we used to perform a `Substring` operation and in order to keep `TryMatch(Predicate<char> test, out string value)` from breaking we have to immediately convert the `Peek`-ed character span back to a string, undoing the apparent optimization in these cases. Still, this all sets things up well for the expansion of the span usages in the next PR.