### PR TITLE
All input traversal works using `ReadOnlySpan<char>` instead of `string`.

### DIFF
--- a/src/Parsley.Tests/ErrorTests.cs
+++ b/src/Parsley.Tests/ErrorTests.cs
@@ -2,49 +2,36 @@ namespace Parsley.Tests;
 
 class ErrorTests
 {
-    readonly Text x;
-    readonly Text endOfInput;
-
-    public ErrorTests()
-    {
-        x = new Text("x");
-        endOfInput = new Text("");
-    }
-
     public void CanIndicateErrorsAtTheCurrentPosition()
     {
-        new Error<object>(endOfInput.Position, ErrorMessage.Unknown()).ErrorMessages.ToString().ShouldBe("Parse error.");
-        new Error<object>(endOfInput.Position, ErrorMessage.Expected("statement")).ErrorMessages.ToString().ShouldBe("statement expected");
+        var error = new Error<object>(new(12, 34), ErrorMessage.Unknown());
+        error.Success.ShouldBe(false);
+        error.ErrorMessages.ToString().ShouldBe("Parse error.");
+        error.Position.ShouldBe(new(12, 34));
+
+        error = new Error<object>(new(23, 45), ErrorMessage.Expected("statement"));
+        error.Success.ShouldBe(false);
+        error.ErrorMessages.ToString().ShouldBe("statement expected");
+        error.Position.ShouldBe(new(23, 45));
     }
 
     public void CanIndicateMultipleErrorsAtTheCurrentPosition()
     {
-        var errors = ErrorMessageList.Empty
+       var errors = ErrorMessageList.Empty
             .With(ErrorMessage.Expected("A"))
             .With(ErrorMessage.Expected("B"));
 
-        new Error<object>(endOfInput.Position, errors).ErrorMessages.ToString().ShouldBe("A or B expected");
+       var error = new Error<object>(new(12, 34), errors);
+       error.Success.ShouldBe(false);
+       error.ErrorMessages.ToString().ShouldBe("A or B expected");
+       error.Position.ShouldBe(new(12, 34));
     }
 
     public void ThrowsWhenAttemptingToGetParsedValue()
     {
-        var inspectParsedValue = () => new Error<object>(x.Position, ErrorMessage.Unknown()).Value;
+        var inspectParsedValue = () => new Error<object>(new(12, 34), ErrorMessage.Unknown()).Value;
         inspectParsedValue
             .ShouldThrow<MemberAccessException>()
-            .Message.ShouldBe("(1, 1): Parse error.");
-    }
-
-    public void HasRemainingUnparsedInput()
-    {
-        var xError = new Error<object>(x.Position, ErrorMessage.Unknown());
-        xError.Position.ShouldBe(x.Position);
-
-        var endError = new Error<object>(endOfInput.Position, ErrorMessage.Unknown());
-        endError.Position.ShouldBe(endOfInput.Position);
-    }
-
-    public void ReportsErrorState()
-    {
-        new Error<object>(x.Position, ErrorMessage.Unknown()).Success.ShouldBeFalse();
+            .Message.ShouldBe("(12, 34): Parse error.");
     }
 }

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -63,8 +63,12 @@ class GrammarTests
 
         parser.FailsToParse("ABABA!", "!", "(1, 6): B expected");
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>("ignored value", input.Position);
-        Action infiniteLoop = () => ZeroOrMore(succeedWithoutConsuming)(new Text(""));
+        Parser<string> succeedWithoutConsuming = (ref Text input) => new Parsed<string>("ignored value", input.Position);
+        Action infiniteLoop = () =>
+        {
+            var input = new Text("");
+            ZeroOrMore(succeedWithoutConsuming)(ref input);
+        };
 
         infiniteLoop
             .ShouldThrow<Exception>()
@@ -85,8 +89,12 @@ class GrammarTests
 
         parser.FailsToParse("ABABA!", "!", "(1, 6): B expected");
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>("ignored value", input.Position);
-        Action infiniteLoop = () => OneOrMore(succeedWithoutConsuming)(new Text(""));
+        Parser<string> succeedWithoutConsuming = (ref Text input) => new Parsed<string>("ignored value", input.Position);
+        Action infiniteLoop = () =>
+        {
+            var input = new Text("");
+            OneOrMore(succeedWithoutConsuming)(ref input);
+        };
 
         infiniteLoop
             .ShouldThrow<Exception>()
@@ -362,7 +370,7 @@ public class AlternationTests
         //consuming input. These tests simply describe the behavior under that
         //unusual situation.
 
-        Parser<string> succeedWithoutConsuming = input => new Parsed<string>("ignored value", input.Position);
+        Parser<string> succeedWithoutConsuming = (ref Text input) => new Parsed<string>("ignored value", input.Position);
 
         var reply = Choice(A, succeedWithoutConsuming).Parses("");
         reply.ErrorMessages.ToString().ShouldBe("A expected");
@@ -375,5 +383,5 @@ public class AlternationTests
     }
 
     static readonly Parser<string> NeverExecuted =
-        input => throw new Exception("Parser 'NeverExecuted' should not have been executed.");
+        (ref Text input) => throw new Exception("Parser 'NeverExecuted' should not have been executed.");
 }

--- a/src/Parsley.Tests/ParsedTests.cs
+++ b/src/Parsley.Tests/ParsedTests.cs
@@ -2,21 +2,14 @@ namespace Parsley.Tests;
 
 class ParsedTests
 {
-    readonly Text unparsed;
-
-    public ParsedTests()
-    {
-        unparsed = new Text("0");
-    }
-
     public void HasAParsedValue()
     {
-        new Parsed<string>("parsed", unparsed.Position).Value.ShouldBe("parsed");
+        new Parsed<string>("parsed", new(1, 1)).Value.ShouldBe("parsed");
     }
 
     public void HasNoErrorMessageByDefault()
     {
-        new Parsed<string>("x", unparsed.Position).ErrorMessages.ShouldBe(ErrorMessageList.Empty);
+        new Parsed<string>("x", new(1, 1)).ErrorMessages.ShouldBe(ErrorMessageList.Empty);
     }
 
     public void CanIndicatePotentialErrors()
@@ -25,17 +18,17 @@ class ParsedTests
             .With(ErrorMessage.Expected("A"))
             .With(ErrorMessage.Expected("B"));
 
-        new Parsed<object>("x", unparsed.Position, potentialErrors).ErrorMessages.ShouldBe(potentialErrors);
+        new Parsed<object>("x", new(1, 1), potentialErrors).ErrorMessages.ShouldBe(potentialErrors);
     }
 
     public void HasRemainingUnparsedInput()
     {
-        var parsed = new Parsed<string>("parsed", unparsed.Position);
-        parsed.Position.ShouldBe(unparsed.Position);
+        var parsed = new Parsed<string>("parsed", new(12, 34));
+        parsed.Position.ShouldBe(new (12, 34));
     }
 
     public void ReportsNonerrorState()
     {
-        new Parsed<string>("parsed", unparsed.Position).Success.ShouldBeTrue();
+        new Parsed<string>("parsed", new(1, 1)).Success.ShouldBeTrue();
     }
 }

--- a/src/Parsley.Tests/ParsedTests.cs
+++ b/src/Parsley.Tests/ParsedTests.cs
@@ -2,33 +2,25 @@ namespace Parsley.Tests;
 
 class ParsedTests
 {
-    public void HasAParsedValue()
+    public void CanIndicateSuccessfullyParsedValueAtTheCurrentPosition()
     {
-        new Parsed<string>("parsed", new(1, 1)).Value.ShouldBe("parsed");
+        var parsed = new Parsed<string>("parsed", new(12, 34));
+        parsed.Success.ShouldBe(true);
+        parsed.Value.ShouldBe("parsed");
+        parsed.ErrorMessages.ShouldBe(ErrorMessageList.Empty);
+        parsed.Position.ShouldBe(new(12, 34));
     }
 
-    public void HasNoErrorMessageByDefault()
-    {
-        new Parsed<string>("x", new(1, 1)).ErrorMessages.ShouldBe(ErrorMessageList.Empty);
-    }
-
-    public void CanIndicatePotentialErrors()
+    public void CanIndicatePotentialErrorMessagesAtTheCurrentPosition()
     {
         var potentialErrors = ErrorMessageList.Empty
             .With(ErrorMessage.Expected("A"))
             .With(ErrorMessage.Expected("B"));
 
-        new Parsed<object>("x", new(1, 1), potentialErrors).ErrorMessages.ShouldBe(potentialErrors);
-    }
-
-    public void HasRemainingUnparsedInput()
-    {
-        var parsed = new Parsed<string>("parsed", new(12, 34));
-        parsed.Position.ShouldBe(new (12, 34));
-    }
-
-    public void ReportsNonerrorState()
-    {
-        new Parsed<string>("parsed", new(1, 1)).Success.ShouldBeTrue();
+        var parsed = new Parsed<object>("parsed", new(12, 34), potentialErrors);
+        parsed.Success.ShouldBe(true);
+        parsed.Value.ShouldBe("parsed");
+        parsed.ErrorMessages.ShouldBe(potentialErrors);
+        parsed.Position.ShouldBe(new(12, 34));
     }
 }

--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -4,7 +4,7 @@ namespace Parsley.Tests;
 
 class ParserQueryTests
 {
-    static readonly Parser<char> Next = input =>
+    static readonly Parser<char> Next = (ref Text input) =>
     {
         var next = input.Peek(1);
 

--- a/src/Parsley.Tests/TextTests.cs
+++ b/src/Parsley.Tests/TextTests.cs
@@ -34,23 +34,23 @@ class TextTests
         abc.Advance(0);
         abc.ToString().ShouldBe("abc");
 
-        var snapshot = abc.Snapshot();
+        var snapshot = abc;
         abc.Advance(1);
         abc.ToString().ShouldBe("bc");
 
-        abc.Restore(snapshot);
+        abc = snapshot;
         abc.Advance(2);
         abc.ToString().ShouldBe("c");
 
-        abc.Restore(snapshot);
+        abc = snapshot;
         abc.Advance(3);
         abc.ToString().ShouldBe("");
 
-        abc.Restore(snapshot);
+        abc = snapshot;
         abc.Advance(4);
         abc.ToString().ShouldBe("");
 
-        abc.Restore(snapshot);
+        abc = snapshot;
         abc.Advance(100);
         abc.ToString().ShouldBe("");
     }
@@ -116,50 +116,50 @@ class TextTests
             .Append("Line 3\n");//Index 14-19, \n
         var list = new Text(lines.ToString());
 
-        var snapshot = list.Snapshot();
+        var snapshot = list;
         list.Advance(0);
         list.Position.ShouldBe(new Position(1, 1));
 
-        list.Restore(snapshot);
+        list = snapshot;
         list.Advance(5);
         list.Position.ShouldBe(new Position(1, 6));
 
-        list.Restore(snapshot);
+        list = snapshot;
         list.Advance(6);
         list.Position.ShouldBe(new Position(1, 7));
 
 
-        list.Restore(snapshot);
+        list = snapshot;
         list.Advance(7);
         list.Position.ShouldBe(new Position(2, 1));
 
-        list.Restore(snapshot);
+        list = snapshot;
         list.Advance(12);
         list.Position.ShouldBe(new Position(2, 6));
 
-        list.Restore(snapshot);
+        list = snapshot;
         list.Advance(13);
         list.Position.ShouldBe(new Position(2, 7));
 
 
-        list.Restore(snapshot);
+        list = snapshot;
         list.Advance(14);
         list.Position.ShouldBe(new Position(3, 1));
 
-        list.Restore(snapshot);
+        list = snapshot;
         list.Advance(19);
         list.Position.ShouldBe(new Position(3, 6));
 
-        list.Restore(snapshot);
+        list = snapshot;
         list.Advance(20);
         list.Position.ShouldBe(new Position(3, 7));
 
 
-        list.Restore(snapshot);
+        list = snapshot;
         list.Advance(21);
         list.Position.ShouldBe(new Position(4, 1));
 
-        list.Restore(snapshot);
+        list = snapshot;
         list.Advance(1000);
         list.Position.ShouldBe(new Position(4, 1));
     }

--- a/src/Parsley.Tests/TextTests.cs
+++ b/src/Parsley.Tests/TextTests.cs
@@ -68,40 +68,27 @@ class TextTests
         Predicate<char> alphanumerics = char.IsLetterOrDigit;
 
         var empty = new Text("");
-        empty.TryMatch(letters, out var value).ShouldBe(false);
-        value.ToString().ShouldBe("");
+        empty.TakeWhile(letters).ToString().ShouldBe("");
 
         var abc123 = new Text("abc123");
-        abc123.TryMatch(digits, out value).ShouldBe(false);
-        value.ToString().ShouldBe("");
-        abc123.TryMatch(letters, out value).ShouldBe(true);
-        value.ToString().ShouldBe("abc");
-        abc123.TryMatch(alphanumerics, out value).ShouldBe(true);
-        value.ToString().ShouldBe("abc123");
+        abc123.TakeWhile(digits).ToString().ShouldBe("");
+        abc123.TakeWhile(letters).ToString().ShouldBe("abc");
+        abc123.TakeWhile(alphanumerics).ToString().ShouldBe("abc123");
 
         abc123.Advance(2);
-        abc123.TryMatch(digits, out value).ShouldBe(false);
-        value.ToString().ShouldBe("");
-        abc123.TryMatch(letters, out value).ShouldBe(true);
-        value.ToString().ShouldBe("c");
-        abc123.TryMatch(alphanumerics, out value).ShouldBe(true);
-        value.ToString().ShouldBe("c123");
+        abc123.TakeWhile(digits).ToString().ShouldBe("");
+        abc123.TakeWhile(letters).ToString().ShouldBe("c");
+        abc123.TakeWhile(alphanumerics).ToString().ShouldBe("c123");
 
         abc123.Advance(1);
-        abc123.TryMatch(digits, out value).ShouldBe(true);
-        value.ToString().ShouldBe("123");
-        abc123.TryMatch(letters, out value).ShouldBe(false);
-        value.ToString().ShouldBe("");
-        abc123.TryMatch(alphanumerics, out value).ShouldBe(true);
-        value.ToString().ShouldBe("123");
+        abc123.TakeWhile(digits).ToString().ShouldBe("123");
+        abc123.TakeWhile(letters).ToString().ShouldBe("");
+        abc123.TakeWhile(alphanumerics).ToString().ShouldBe("123");
 
         abc123.Advance(3);
-        abc123.TryMatch(digits, out value).ShouldBe(false);
-        value.ToString().ShouldBe("");
-        abc123.TryMatch(letters, out value).ShouldBe(false);
-        value.ToString().ShouldBe("");
-        abc123.TryMatch(alphanumerics, out value).ShouldBe(false);
-        value.ToString().ShouldBe("");
+        abc123.TakeWhile(digits).ToString().ShouldBe("");
+        abc123.TakeWhile(letters).ToString().ShouldBe("");
+        abc123.TakeWhile(alphanumerics).ToString().ShouldBe("");
     }
 
     public void CanGetCurrentPosition()

--- a/src/Parsley.Tests/TextTests.cs
+++ b/src/Parsley.Tests/TextTests.cs
@@ -69,39 +69,39 @@ class TextTests
 
         var empty = new Text("");
         empty.TryMatch(letters, out var value).ShouldBe(false);
-        value.ShouldBe("");
+        value.ToString().ShouldBe("");
 
         var abc123 = new Text("abc123");
         abc123.TryMatch(digits, out value).ShouldBe(false);
-        value.ShouldBe("");
+        value.ToString().ShouldBe("");
         abc123.TryMatch(letters, out value).ShouldBe(true);
-        value.ShouldBe("abc");
+        value.ToString().ShouldBe("abc");
         abc123.TryMatch(alphanumerics, out value).ShouldBe(true);
-        value.ShouldBe("abc123");
+        value.ToString().ShouldBe("abc123");
 
         abc123.Advance(2);
         abc123.TryMatch(digits, out value).ShouldBe(false);
-        value.ShouldBe("");
+        value.ToString().ShouldBe("");
         abc123.TryMatch(letters, out value).ShouldBe(true);
-        value.ShouldBe("c");
+        value.ToString().ShouldBe("c");
         abc123.TryMatch(alphanumerics, out value).ShouldBe(true);
-        value.ShouldBe("c123");
+        value.ToString().ShouldBe("c123");
 
         abc123.Advance(1);
         abc123.TryMatch(digits, out value).ShouldBe(true);
-        value.ShouldBe("123");
+        value.ToString().ShouldBe("123");
         abc123.TryMatch(letters, out value).ShouldBe(false);
-        value.ShouldBe("");
+        value.ToString().ShouldBe("");
         abc123.TryMatch(alphanumerics, out value).ShouldBe(true);
-        value.ShouldBe("123");
+        value.ToString().ShouldBe("123");
 
         abc123.Advance(3);
         abc123.TryMatch(digits, out value).ShouldBe(false);
-        value.ShouldBe("");
+        value.ToString().ShouldBe("");
         abc123.TryMatch(letters, out value).ShouldBe(false);
-        value.ShouldBe("");
+        value.ToString().ShouldBe("");
         abc123.TryMatch(alphanumerics, out value).ShouldBe(false);
-        value.ShouldBe("");
+        value.ToString().ShouldBe("");
     }
 
     public void CanGetCurrentPosition()

--- a/src/Parsley/Assertions.cs
+++ b/src/Parsley/Assertions.cs
@@ -5,7 +5,7 @@ public static class Assertions
     public static Reply<T> FailsToParse<T>(this Parser<T> parse, string input, string expectedUnparsedInput, string expectedMessage)
     {
         var text = new Text(input);
-        var reply = parse(text);
+        var reply = parse(ref text);
             
         if (reply.Success)
             throw new AssertionException("parser failure", "parser completed successfully");
@@ -43,7 +43,7 @@ public static class Assertions
     {
         var text = new Text(input);
 
-        var reply = parse(text).Succeeds();
+        var reply = parse(ref text).Succeeds();
 
         text.LeavingUnparsedInput(expectedUnparsedInput);
 
@@ -53,7 +53,7 @@ public static class Assertions
     public static Reply<T> Parses<T>(this Parser<T> parse, string input)
     {
         var text = new Text(input);
-        var reply = parse(text).Succeeds();
+        var reply = parse(ref text).Succeeds();
 
         text.AtEndOfInput();
 

--- a/src/Parsley/Grammar.Attempt.cs
+++ b/src/Parsley/Grammar.Attempt.cs
@@ -11,7 +11,7 @@ partial class Grammar
     {
         return (ref Text input) =>
         {
-            var snapshot = input.Snapshot();
+            var snapshot = input;
             var start = input.Position;
             var reply = parse(ref input);
             var newPosition = input.Position;
@@ -19,7 +19,7 @@ partial class Grammar
             if (reply.Success || start == newPosition)
                 return reply;
 
-            input.Restore(snapshot);
+            input = snapshot;
             return new Error<T>(input.Position, ErrorMessage.Backtrack(newPosition, reply.ErrorMessages));
         };
     }

--- a/src/Parsley/Grammar.Attempt.cs
+++ b/src/Parsley/Grammar.Attempt.cs
@@ -9,11 +9,11 @@ partial class Grammar
     /// </summary>
     public static Parser<T> Attempt<T>(Parser<T> parse)
     {
-        return input =>
+        return (ref Text input) =>
         {
             var snapshot = input.Snapshot();
             var start = input.Position;
-            var reply = parse(input);
+            var reply = parse(ref input);
             var newPosition = input.Position;
 
             if (reply.Success || start == newPosition)

--- a/src/Parsley/Grammar.Character.cs
+++ b/src/Parsley/Grammar.Character.cs
@@ -9,7 +9,7 @@ partial class Grammar
 
     public static Parser<char> Character(Predicate<char> test, string name)
     {
-        return input =>
+        return (ref Text input) =>
         {
             var next = input.Peek(1);
 

--- a/src/Parsley/Grammar.Choice.cs
+++ b/src/Parsley/Grammar.Choice.cs
@@ -25,10 +25,10 @@ partial class Grammar
         if (parsers.Length == 0)
             return Grammar<T>.Fail;
 
-        return input =>
+        return (ref Text input) =>
         {
             var start = input.Position;
-            var reply = parsers[0](input);
+            var reply = parsers[0](ref input);
             var newPosition = input.Position;
 
             var errors = ErrorMessageList.Empty;
@@ -37,7 +37,7 @@ partial class Grammar
             while (!reply.Success && (start == newPosition) && i < parsers.Length)
             {
                 errors = errors.Merge(reply.ErrorMessages);
-                reply = parsers[i](input);
+                reply = parsers[i](ref input);
                 newPosition = input.Position;
                 i++;
             }

--- a/src/Parsley/Grammar.EndOfInput.cs
+++ b/src/Parsley/Grammar.EndOfInput.cs
@@ -3,7 +3,7 @@ namespace Parsley;
 partial class Grammar
 {
     public static readonly Parser<string> EndOfInput =
-        input => input.EndOfInput
+        (ref Text input) => input.EndOfInput
             ? new Parsed<string>("", input.Position)
             : new Error<string>(input.Position, ErrorMessage.Expected("end of input"));
 }

--- a/src/Parsley/Grammar.Fail.cs
+++ b/src/Parsley/Grammar.Fail.cs
@@ -2,5 +2,5 @@ namespace Parsley;
 
 public partial class Grammar<T>
 {
-    public static readonly Parser<T> Fail = input => new Error<T>(input.Position, ErrorMessage.Unknown());
+    public static readonly Parser<T> Fail = (ref Text input) => new Error<T>(input.Position, ErrorMessage.Unknown());
 }

--- a/src/Parsley/Grammar.Keyword.cs
+++ b/src/Parsley/Grammar.Keyword.cs
@@ -7,7 +7,7 @@ partial class Grammar
         if (word.Any(ch => !char.IsLetter(ch)))
             throw new ArgumentException("Keywords may only contain letters.", nameof(word));
 
-        return input =>
+        return (ref Text input) =>
         {
             var peek = input.Peek(word.Length + 1);
 

--- a/src/Parsley/Grammar.Label.cs
+++ b/src/Parsley/Grammar.Label.cs
@@ -11,10 +11,10 @@ partial class Grammar
     {
         var errors = ErrorMessageList.Empty.With(ErrorMessage.Expected(expectation));
 
-        return input =>
+        return (ref Text input) =>
         {
             var start = input.Position;
-            var reply = parse(input);
+            var reply = parse(ref input);
             var newPosition = input.Position;
 
             if (start == newPosition)

--- a/src/Parsley/Grammar.Operator.cs
+++ b/src/Parsley/Grammar.Operator.cs
@@ -4,7 +4,7 @@ partial class Grammar
 {
     public static Parser<string> Operator(string symbol)
     {
-        return input =>
+        return (ref Text input) =>
         {
             var peek = input.Peek(symbol.Length);
 

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -10,10 +10,10 @@ partial class Grammar
     /// </summary>
     public static Parser<IEnumerable<T>> ZeroOrMore<T>(Parser<T> item)
     {
-        return input =>
+        return (ref Text input) =>
         {
             var oldPosition = input.Position;
-            var reply = item(input);
+            var reply = item(ref input);
             var newPosition = input.Position;
 
             var list = new List<T>();
@@ -25,7 +25,7 @@ partial class Grammar
 
                 list.Add(reply.Value);
                 oldPosition = newPosition;
-                reply = item(input);
+                reply = item(ref input);
                 newPosition = input.Position;
             }
 
@@ -71,7 +71,7 @@ partial class Grammar
 
     public static Parser<string> ZeroOrMore(Predicate<char> test)
     {
-        return input =>
+        return (ref Text input) =>
         {
             if (input.TryMatch(test, out var value))
             {
@@ -86,7 +86,7 @@ partial class Grammar
 
     public static Parser<string> OneOrMore(Predicate<char> test, string name)
     {
-        return input =>
+        return (ref Text input) =>
         {
             if (input.TryMatch(test, out var value))
             {

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -77,7 +77,7 @@ partial class Grammar
             {
                 input.Advance(value.Length);
 
-                return new Parsed<string>(value, input.Position);
+                return new Parsed<string>(value.ToString(), input.Position);
             }
 
             return new Parsed<string>("", input.Position);
@@ -92,7 +92,7 @@ partial class Grammar
             {
                 input.Advance(value.Length);
 
-                return new Parsed<string>(value, input.Position);
+                return new Parsed<string>(value.ToString(), input.Position);
             }
 
             return new Error<string>(input.Position, ErrorMessage.Expected(name));

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -73,7 +73,9 @@ partial class Grammar
     {
         return (ref Text input) =>
         {
-            if (input.TryMatch(test, out var value))
+            var value = input.TakeWhile(test);
+
+            if (value.Length > 0)
             {
                 input.Advance(value.Length);
 
@@ -88,7 +90,9 @@ partial class Grammar
     {
         return (ref Text input) =>
         {
-            if (input.TryMatch(test, out var value))
+            var value = input.TakeWhile(test);
+
+            if (value.Length > 0)
             {
                 input.Advance(value.Length);
 

--- a/src/Parsley/OperatorPrecedenceParser.cs
+++ b/src/Parsley/OperatorPrecedenceParser.cs
@@ -94,9 +94,9 @@ public class OperatorPrecedenceParser<T>
 
         foreach(var (kind, parser) in unitParsers)
         {
-            var snapshot = input.Snapshot();
+            var snapshot = input;
             var reply = kind(ref input);
-            input.Restore(snapshot);
+            input = snapshot;
 
             if (reply.Success)
             {
@@ -117,9 +117,9 @@ public class OperatorPrecedenceParser<T>
 
         foreach (var (kind, precedence, extendParserBuilder) in extendParsers)
         {
-            var snapshot = input.Snapshot();
+            var snapshot = input;
             var reply = kind(ref input);
-            input.Restore(snapshot);
+            input = snapshot;
 
             if (reply.Success)
             {

--- a/src/Parsley/Parser.cs
+++ b/src/Parsley/Parser.cs
@@ -1,3 +1,3 @@
 namespace Parsley;
 
-public delegate Reply<T> Parser<out T>(Text input);
+public delegate Reply<T> Parser<out T>(ref Text input);

--- a/src/Parsley/ParserQuery.cs
+++ b/src/Parsley/ParserQuery.cs
@@ -12,7 +12,7 @@ public static class ParserQuery
     /// <param name="value">The value to treat as a parse result.</param>
     public static Parser<T> SucceedWithThisValue<T>(this T value)
     {
-        return input => new Parsed<T>(value, input.Position);
+        return (ref Text input) => new Parsed<T>(value, input.Position);
     }
 
     /// <summary>
@@ -39,12 +39,12 @@ public static class ParserQuery
     /// </remarks>
     static Parser<U> Bind<T, U>(this Parser<T> parse, Func<T, Parser<U>> constructNextParser)
     {
-        return input =>
+        return (ref Text input) =>
         {
-            var reply = parse(input);
+            var reply = parse(ref input);
 
             if (reply.Success)
-                return constructNextParser(reply.Value)(input);
+                return constructNextParser(reply.Value)(ref input);
 
             return new Error<U>(reply.Position, reply.ErrorMessages);
         };

--- a/src/Parsley/Text.cs
+++ b/src/Parsley/Text.cs
@@ -48,14 +48,14 @@ public ref struct Text
 
     public bool EndOfInput => index >= input.Length;
 
-    public bool TryMatch(Predicate<char> test, out string value)
+    public bool TryMatch(Predicate<char> test, out ReadOnlySpan<char> value)
     {
         int i = index;
 
         while (i < input.Length && test(input[i]))
             i++;
 
-        value = Peek(i - index).ToString();
+        value = Peek(i - index);
 
         return value.Length > 0;
     }

--- a/src/Parsley/Text.cs
+++ b/src/Parsley/Text.cs
@@ -3,7 +3,7 @@ namespace Parsley;
 public ref struct Text
 {
     int index;
-    readonly string input;
+    readonly ReadOnlySpan<char> input;
     int line;
 
     public Text(string input)
@@ -22,8 +22,8 @@ public ref struct Text
 
     public ReadOnlySpan<char> Peek(int characters)
         => index + characters >= input.Length
-            ? input.AsSpan().Slice(index)
-            : input.AsSpan().Slice(index, characters);
+            ? input.Slice(index)
+            : input.Slice(index, characters);
 
     public void Advance(int characters)
     {
@@ -67,7 +67,7 @@ public ref struct Text
             if (index == 0)
                 return 1;
 
-            int indexOfPreviousNewLine = input.LastIndexOf('\n', index - 1);
+            int indexOfPreviousNewLine = input[..index].LastIndexOf('\n');
             return index - indexOfPreviousNewLine;
         }
     }
@@ -85,5 +85,5 @@ public ref struct Text
     }
 
     public override string ToString()
-        => input.Substring(index);
+        => input.Slice(index).ToString();
 }

--- a/src/Parsley/Text.cs
+++ b/src/Parsley/Text.cs
@@ -1,6 +1,6 @@
 namespace Parsley;
 
-public class Text
+public ref struct Text
 {
     int index;
     readonly string input;

--- a/src/Parsley/Text.cs
+++ b/src/Parsley/Text.cs
@@ -75,15 +75,6 @@ public ref struct Text
     public Position Position
         => new(line, Column);
 
-    public (int index, int line) Snapshot()
-        => (index, line);
-
-    public void Restore((int index, int line) snapshot)
-    {
-        index = snapshot.index;
-        line = snapshot.line;
-    }
-
     public override string ToString()
         => input.Slice(index).ToString();
 }

--- a/src/Parsley/Text.cs
+++ b/src/Parsley/Text.cs
@@ -48,16 +48,14 @@ public ref struct Text
 
     public readonly bool EndOfInput => index >= input.Length;
 
-    public readonly bool TryMatch(Predicate<char> test, out ReadOnlySpan<char> value)
+    public readonly ReadOnlySpan<char> TakeWhile(Predicate<char> test)
     {
         int i = index;
 
         while (i < input.Length && test(input[i]))
             i++;
 
-        value = Peek(i - index);
-
-        return value.Length > 0;
+        return Peek(i - index);
     }
 
     readonly int Column

--- a/src/Parsley/Text.cs
+++ b/src/Parsley/Text.cs
@@ -6,10 +6,10 @@ public ref struct Text
     readonly ReadOnlySpan<char> input;
     int line;
 
-    public Text(string input)
+    public Text(ReadOnlySpan<char> input)
         : this(input, 0, 1) { }
 
-    Text(string input, int index, int line)
+    Text(ReadOnlySpan<char> input, int index, int line)
     {
         this.input = input;
         this.index = index;

--- a/src/Parsley/Text.cs
+++ b/src/Parsley/Text.cs
@@ -20,7 +20,7 @@ public ref struct Text
         this.line = line;
     }
 
-    public ReadOnlySpan<char> Peek(int characters)
+    public readonly ReadOnlySpan<char> Peek(int characters)
         => index + characters >= input.Length
             ? input.Slice(index)
             : input.Slice(index, characters);
@@ -46,9 +46,9 @@ public ref struct Text
             index = input.Length;
     }
 
-    public bool EndOfInput => index >= input.Length;
+    public readonly bool EndOfInput => index >= input.Length;
 
-    public bool TryMatch(Predicate<char> test, out ReadOnlySpan<char> value)
+    public readonly bool TryMatch(Predicate<char> test, out ReadOnlySpan<char> value)
     {
         int i = index;
 
@@ -60,7 +60,7 @@ public ref struct Text
         return value.Length > 0;
     }
 
-    int Column
+    readonly int Column
     {
         get
         {
@@ -72,9 +72,9 @@ public ref struct Text
         }
     }
 
-    public Position Position
+    public readonly Position Position
         => new(line, Column);
 
-    public override string ToString()
+    public readonly override string ToString()
         => input.Slice(index).ToString();
 }


### PR DESCRIPTION
This improves all traversal through the input string by converting the `Text` `string`-wrapper `class` into a stack-only `ReadOnlySpan<char>`-wrapping `ref struct` and replacing the many `Substring` operations with equivalent but more efficient `Slice` operations.

While it's tempting to just aggressively edit `public class Text` to `public ref struct Text` and then chase compiler errors from there, here the commit history shows a safer approach. Knowing what compiler errors *would* have occurred, we "get ahead" of them one at a time by performing changes that would be sound on their own. By the time it gets to the commit that actually alters the declaration of `Text`, there's nothing else to do in that moment. This kept the system building and passing tests throughout developerment, which is particularly helpful here as there are *many* subtle restrictions enforced on spans by the compiler.

Benefits:

* Text's string field has been promoted to a `ReadOnlySpan<char>`, and this has been leveraged as far as possible so we have far greater *opportunity* moving forward to minimize allocations. We hit a wall so far in that the `Reply` types are still classes, and so must be given the realized strings.
* This sets us up for future attempts to generalize Parsley's ability to recognize patterns beyond `char` sequences. Most of the remaining code doesn't particularly care about the item type being `char`.

Consequences:

* `Parser<T>(Text input)`, the fundamental delegate type for the library, has become `Parser<T>(ref Text input)`. This means every method or lambda expression used as that delegate type now explicitly marks its input with the `ref` keyword. Doing so lets us avoid excess copies of the struct with each call, allows it to be usefully mutable at least in the near term, and generally makes up for the fact that it has pivoted from a reference type to a value type: what was a reference type is now a value type *but one passed by reference* for reference-type-like semantics on each call.
* Still, it is a struct, so *assignment* still performs a copy of the operator's right-hand-side. This was in fact a benefit, as it simplified away the old Snapshot()/Restore(snapshot) flow for the few places that needed backtracking behavior.