### PR TITLE
Phase out Reply.Position

### DIFF
--- a/src/Parsley.Tests/ErrorTests.cs
+++ b/src/Parsley.Tests/ErrorTests.cs
@@ -32,6 +32,6 @@ class ErrorTests
         var inspectParsedValue = () => new Error<object>(new(12, 34), ErrorMessage.Unknown()).Value;
         inspectParsedValue
             .ShouldThrow<MemberAccessException>()
-            .Message.ShouldBe("(12, 34): Parse error.");
+            .Message.ShouldBe("Parse error.");
     }
 }

--- a/src/Parsley.Tests/ErrorTests.cs
+++ b/src/Parsley.Tests/ErrorTests.cs
@@ -2,34 +2,31 @@ namespace Parsley.Tests;
 
 class ErrorTests
 {
-    public void CanIndicateErrorsAtTheCurrentPosition()
+    public void CanIndicateErrors()
     {
-        var error = new Error<object>(new(12, 34), ErrorMessage.Unknown());
+        var error = new Error<object>(ErrorMessage.Unknown());
         error.Success.ShouldBe(false);
         error.ErrorMessages.ToString().ShouldBe("Parse error.");
-        error.Position.ShouldBe(new(12, 34));
 
-        error = new Error<object>(new(23, 45), ErrorMessage.Expected("statement"));
+        error = new Error<object>(ErrorMessage.Expected("statement"));
         error.Success.ShouldBe(false);
         error.ErrorMessages.ToString().ShouldBe("statement expected");
-        error.Position.ShouldBe(new(23, 45));
     }
 
-    public void CanIndicateMultipleErrorsAtTheCurrentPosition()
+    public void CanIndicateMultipleErrors()
     {
        var errors = ErrorMessageList.Empty
             .With(ErrorMessage.Expected("A"))
             .With(ErrorMessage.Expected("B"));
 
-       var error = new Error<object>(new(12, 34), errors);
+       var error = new Error<object>(errors);
        error.Success.ShouldBe(false);
        error.ErrorMessages.ToString().ShouldBe("A or B expected");
-       error.Position.ShouldBe(new(12, 34));
     }
 
     public void ThrowsWhenAttemptingToGetParsedValue()
     {
-        var inspectParsedValue = () => new Error<object>(new(12, 34), ErrorMessage.Unknown()).Value;
+        var inspectParsedValue = () => new Error<object>(ErrorMessage.Unknown()).Value;
         inspectParsedValue
             .ShouldThrow<MemberAccessException>()
             .Message.ShouldBe("Parse error.");

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -63,7 +63,7 @@ class GrammarTests
 
         parser.FailsToParse("ABABA!", "!", "(1, 6): B expected");
 
-        Parser<string> succeedWithoutConsuming = (ref Text input) => new Parsed<string>("ignored value", input.Position);
+        Parser<string> succeedWithoutConsuming = (ref Text input) => new Parsed<string>("ignored value");
         Action infiniteLoop = () =>
         {
             var input = new Text("");
@@ -89,7 +89,7 @@ class GrammarTests
 
         parser.FailsToParse("ABABA!", "!", "(1, 6): B expected");
 
-        Parser<string> succeedWithoutConsuming = (ref Text input) => new Parsed<string>("ignored value", input.Position);
+        Parser<string> succeedWithoutConsuming = (ref Text input) => new Parsed<string>("ignored value");
         Action infiniteLoop = () =>
         {
             var input = new Text("");
@@ -368,7 +368,7 @@ public class AlternationTests
         //consuming input. These tests simply describe the behavior under that
         //unusual situation.
 
-        Parser<string> succeedWithoutConsuming = (ref Text input) => new Parsed<string>("atypical value", input.Position);
+        Parser<string> succeedWithoutConsuming = (ref Text input) => new Parsed<string>("atypical value");
 
         Choice(A, succeedWithoutConsuming).Parses("", "(1, 1): A expected").Value.ShouldBe("atypical value");
         Choice(A, B, succeedWithoutConsuming).Parses("", "(1, 1): A or B expected").Value.ShouldBe("atypical value");

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -368,16 +368,11 @@ public class AlternationTests
         //consuming input. These tests simply describe the behavior under that
         //unusual situation.
 
-        Parser<string> succeedWithoutConsuming = (ref Text input) => new Parsed<string>("ignored value", input.Position);
+        Parser<string> succeedWithoutConsuming = (ref Text input) => new Parsed<string>("atypical value", input.Position);
 
-        var reply = Choice(A, succeedWithoutConsuming).Parses("", "(1, 1): A expected");
-        reply.ErrorMessages.ToString().ShouldBe("A expected");
-
-        reply = Choice(A, B, succeedWithoutConsuming).Parses("", "(1, 1): A or B expected");
-        reply.ErrorMessages.ToString().ShouldBe("A or B expected");
-
-        reply = Choice(A, succeedWithoutConsuming, B).Parses("", "(1, 1): A expected");
-        reply.ErrorMessages.ToString().ShouldBe("A expected");
+        Choice(A, succeedWithoutConsuming).Parses("", "(1, 1): A expected").Value.ShouldBe("atypical value");
+        Choice(A, B, succeedWithoutConsuming).Parses("", "(1, 1): A or B expected").Value.ShouldBe("atypical value");
+        Choice(A, succeedWithoutConsuming, B).Parses("", "(1, 1): A expected").Value.ShouldBe("atypical value");
     }
 
     static readonly Parser<string> NeverExecuted =

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -53,7 +53,7 @@ class GrammarTests
     {
         var parser = ZeroOrMore(AB);
 
-        parser.Parses("").Value.ShouldBeEmpty();
+        parser.Parses("", "(1, 1): A expected").Value.ShouldBeEmpty();
 
         parser.PartiallyParses("AB!", "!", "(1, 3): A expected")
             .Value.Single().ShouldBe("AB");
@@ -105,7 +105,7 @@ class GrammarTests
     {
         var parser = ZeroOrMore(AB, COMMA);
 
-        parser.Parses("").Value.ShouldBeEmpty();
+        parser.Parses("", "(1, 1): A expected").Value.ShouldBeEmpty();
         parser.Parses("AB").Value.Single().ShouldBe("AB");
         parser.Parses("AB,AB").Value.ShouldBe(new[] { "AB", "AB" });
         parser.Parses("AB,AB,AB").Value.ShouldBe(new[] { "AB", "AB", "AB" });
@@ -166,8 +166,8 @@ class GrammarTests
         var labeled = Label(AB, "'A' followed by 'B'");
 
         //When p succeeds after consuming input, Label(p) is the same as p.
-        AB.Parses("AB").WithNoMessage().Value.ShouldBe("AB");
-        labeled.Parses("AB").WithNoMessage().Value.ShouldBe("AB");
+        AB.Parses("AB").Value.ShouldBe("AB");
+        labeled.Parses("AB").Value.ShouldBe("AB");
 
         //When p fails after consuming input, Label(p) is the same as p.
         AB.FailsToParse("A!", "!", "(1, 2): B expected");
@@ -177,7 +177,6 @@ class GrammarTests
         var succeedWithoutConsuming = "$".SucceedWithThisValue();
         succeedWithoutConsuming
             .PartiallyParses("!", "!")
-            .WithNoMessage()
             .Value.ShouldBe("$");
         Label(succeedWithoutConsuming, "nothing")
             .PartiallyParses("!", "!", "(1, 1): nothing expected")
@@ -371,13 +370,13 @@ public class AlternationTests
 
         Parser<string> succeedWithoutConsuming = (ref Text input) => new Parsed<string>("ignored value", input.Position);
 
-        var reply = Choice(A, succeedWithoutConsuming).Parses("");
+        var reply = Choice(A, succeedWithoutConsuming).Parses("", "(1, 1): A expected");
         reply.ErrorMessages.ToString().ShouldBe("A expected");
 
-        reply = Choice(A, B, succeedWithoutConsuming).Parses("");
+        reply = Choice(A, B, succeedWithoutConsuming).Parses("", "(1, 1): A or B expected");
         reply.ErrorMessages.ToString().ShouldBe("A or B expected");
 
-        reply = Choice(A, succeedWithoutConsuming, B).Parses("");
+        reply = Choice(A, succeedWithoutConsuming, B).Parses("", "(1, 1): A expected");
         reply.ErrorMessages.ToString().ShouldBe("A expected");
     }
 

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -136,7 +136,7 @@ class GrammarTests
         Optional(A).PartiallyParses("AB.", "B.").Value.ShouldBe('A');
         Optional(A).PartiallyParses(".", ".", "(1, 1): A expected").Value.ShouldBe(null);
         Optional(B).PartiallyParses("A", "A", "(1, 1): B expected").Value.ShouldBe(null);
-        Optional(B).PartiallyParses("", "", "(1, 1): B expected").Value.ShouldBe(null);
+        Optional(B).Parses("", "(1, 1): B expected").Value.ShouldBe(null);
 
         //Alternate possibilities are not supported when nullable
         //reference types are enabled:

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -55,10 +55,10 @@ class GrammarTests
 
         parser.Parses("").Value.ShouldBeEmpty();
 
-        parser.PartiallyParses("AB!", "!")
+        parser.PartiallyParses("AB!", "!", "(1, 3): A expected")
             .Value.Single().ShouldBe("AB");
 
-        parser.PartiallyParses("ABAB!", "!")
+        parser.PartiallyParses("ABAB!", "!", "(1, 5): A expected")
             .Value.ShouldBe(new[] { "AB", "AB" });
 
         parser.FailsToParse("ABABA!", "!", "(1, 6): B expected");
@@ -129,14 +129,14 @@ class GrammarTests
     {
         //Reference Type to Nullable Reference Type
         Optional(AB).PartiallyParses("AB.", ".").Value.ShouldBe("AB");
-        Optional(AB).PartiallyParses(".", ".").Value.ShouldBe(null);
+        Optional(AB).PartiallyParses(".", ".", "(1, 1): A expected").Value.ShouldBe(null);
         Optional(AB).FailsToParse("AC.", "C.", "(1, 2): B expected");
 
         //Value Type to Nullable Value Type
         Optional(A).PartiallyParses("AB.", "B.").Value.ShouldBe('A');
-        Optional(A).PartiallyParses(".", ".").Value.ShouldBe(null);
-        Optional(B).PartiallyParses("A", "A").Value.ShouldBe(null);
-        Optional(B).PartiallyParses("", "").Value.ShouldBe(null);
+        Optional(A).PartiallyParses(".", ".", "(1, 1): A expected").Value.ShouldBe(null);
+        Optional(B).PartiallyParses("A", "A", "(1, 1): B expected").Value.ShouldBe(null);
+        Optional(B).PartiallyParses("", "", "(1, 1): B expected").Value.ShouldBe(null);
 
         //Alternate possibilities are not supported when nullable
         //reference types are enabled:
@@ -180,8 +180,7 @@ class GrammarTests
             .WithNoMessage()
             .Value.ShouldBe("$");
         Label(succeedWithoutConsuming, "nothing")
-            .PartiallyParses("!", "!")
-            .WithMessage("(1, 1): nothing expected")
+            .PartiallyParses("!", "!", "(1, 1): nothing expected")
             .Value.ShouldBe("$");
 
         //When p fails but does not consume input, Label(p) fails with the given expectation.

--- a/src/Parsley.Tests/ParsedTests.cs
+++ b/src/Parsley.Tests/ParsedTests.cs
@@ -2,25 +2,23 @@ namespace Parsley.Tests;
 
 class ParsedTests
 {
-    public void CanIndicateSuccessfullyParsedValueAtTheCurrentPosition()
+    public void CanIndicateSuccessfullyParsedValue()
     {
-        var parsed = new Parsed<string>("parsed", new(12, 34));
+        var parsed = new Parsed<string>("parsed");
         parsed.Success.ShouldBe(true);
         parsed.Value.ShouldBe("parsed");
         parsed.ErrorMessages.ShouldBe(ErrorMessageList.Empty);
-        parsed.Position.ShouldBe(new(12, 34));
     }
 
-    public void CanIndicatePotentialErrorMessagesAtTheCurrentPosition()
+    public void CanIndicatePotentialErrorMessages()
     {
         var potentialErrors = ErrorMessageList.Empty
             .With(ErrorMessage.Expected("A"))
             .With(ErrorMessage.Expected("B"));
 
-        var parsed = new Parsed<object>("parsed", new(12, 34), potentialErrors);
+        var parsed = new Parsed<object>("parsed", potentialErrors);
         parsed.Success.ShouldBe(true);
         parsed.Value.ShouldBe("parsed");
         parsed.ErrorMessages.ShouldBe(potentialErrors);
-        parsed.Position.ShouldBe(new(12, 34));
     }
 }

--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -14,10 +14,10 @@ class ParserQueryTests
 
             input.Advance(1);
 
-            return new Parsed<char>(c, input.Position);
+            return new Parsed<char>(c);
         }
 
-        return new Error<char>(input.Position, ErrorMessage.Expected("character"));
+        return new Error<char>(ErrorMessage.Expected("character"));
     };
 
     public void CanBuildParserWhichSimulatesSuccessfulParsingOfGivenValueWithoutConsumingInput()

--- a/src/Parsley/Assertions.cs
+++ b/src/Parsley/Assertions.cs
@@ -20,6 +20,9 @@ public static class Assertions
         var text = new Text(input);
         var reply = parse(ref text).Succeeds(expectedMessage);
 
+        if (expectedUnparsedInput == "")
+            throw new ArgumentException($"{nameof(expectedUnparsedInput)} must be nonempty when calling {nameof(PartiallyParses)}.");
+
         text.LeavingUnparsedInput(expectedUnparsedInput);
 
         return reply;

--- a/src/Parsley/Assertions.cs
+++ b/src/Parsley/Assertions.cs
@@ -55,12 +55,17 @@ public static class Assertions
         return reply;
     }
 
-    public static Reply<T> Parses<T>(this Parser<T> parse, string input)
+    public static Reply<T> Parses<T>(this Parser<T> parse, string input, string? expectedMessage = null)
     {
         var text = new Text(input);
         var reply = parse(ref text).Succeeds();
 
         text.AtEndOfInput();
+
+        if (expectedMessage == null)
+            reply.WithNoMessage();
+        else
+            reply.WithMessage(expectedMessage);
 
         return reply;
     }

--- a/src/Parsley/Assertions.cs
+++ b/src/Parsley/Assertions.cs
@@ -39,13 +39,18 @@ public static class Assertions
         return reply;
     }
 
-    public static Reply<T> PartiallyParses<T>(this Parser<T> parse, string input, string expectedUnparsedInput)
+    public static Reply<T> PartiallyParses<T>(this Parser<T> parse, string input, string expectedUnparsedInput, string? expectedMessage = null)
     {
         var text = new Text(input);
 
         var reply = parse(ref text).Succeeds();
 
         text.LeavingUnparsedInput(expectedUnparsedInput);
+
+        if (expectedMessage == null)
+            reply.WithNoMessage();
+        else
+            reply.WithMessage(expectedMessage);
 
         return reply;
     }

--- a/src/Parsley/Error.cs
+++ b/src/Parsley/Error.cs
@@ -11,7 +11,7 @@ public class Error<T> : Reply<T>
         ErrorMessages = errors;
     }
 
-    public T Value => throw new MemberAccessException($"{Position}: {ErrorMessages}");
+    public T Value => throw new MemberAccessException($"{ErrorMessages}");
     public Position Position { get; }
     public bool Success => false;
     public ErrorMessageList ErrorMessages { get; }

--- a/src/Parsley/Error.cs
+++ b/src/Parsley/Error.cs
@@ -2,17 +2,13 @@ namespace Parsley;
 
 public class Error<T> : Reply<T>
 {
-    public Error(Position position, ErrorMessage error)
-        : this(position, ErrorMessageList.Empty.With(error)) { }
+    public Error(ErrorMessage error)
+        : this(ErrorMessageList.Empty.With(error)) { }
 
-    public Error(Position position, ErrorMessageList errors)
-    {
-        Position = position;
-        ErrorMessages = errors;
-    }
+    public Error(ErrorMessageList errors)
+        => ErrorMessages = errors;
 
     public T Value => throw new MemberAccessException($"{ErrorMessages}");
-    public Position Position { get; }
     public bool Success => false;
     public ErrorMessageList ErrorMessages { get; }
 }

--- a/src/Parsley/Grammar.Attempt.cs
+++ b/src/Parsley/Grammar.Attempt.cs
@@ -20,7 +20,7 @@ partial class Grammar
                 return reply;
 
             input = snapshot;
-            return new Error<T>(input.Position, ErrorMessage.Backtrack(newPosition, reply.ErrorMessages));
+            return new Error<T>(ErrorMessage.Backtrack(newPosition, reply.ErrorMessages));
         };
     }
 }

--- a/src/Parsley/Grammar.Character.cs
+++ b/src/Parsley/Grammar.Character.cs
@@ -20,11 +20,11 @@ partial class Grammar
                 {
                     input.Advance(1);
 
-                    return new Parsed<char>(c, input.Position);
+                    return new Parsed<char>(c);
                 }
             }
 
-            return new Error<char>(input.Position, ErrorMessage.Expected(name));
+            return new Error<char>(ErrorMessage.Expected(name));
         };
     }
 }

--- a/src/Parsley/Grammar.Choice.cs
+++ b/src/Parsley/Grammar.Choice.cs
@@ -47,9 +47,9 @@ partial class Grammar
                 errors = errors.Merge(reply.ErrorMessages);
 
                 if (reply.Success)
-                    reply = new Parsed<T>(reply.Value, reply.Position, errors);
+                    reply = new Parsed<T>(reply.Value, errors);
                 else
-                    reply = new Error<T>(reply.Position, errors);
+                    reply = new Error<T>(errors);
             }
 
             return reply;

--- a/src/Parsley/Grammar.EndOfInput.cs
+++ b/src/Parsley/Grammar.EndOfInput.cs
@@ -4,6 +4,6 @@ partial class Grammar
 {
     public static readonly Parser<string> EndOfInput =
         (ref Text input) => input.EndOfInput
-            ? new Parsed<string>("", input.Position)
-            : new Error<string>(input.Position, ErrorMessage.Expected("end of input"));
+            ? new Parsed<string>("")
+            : new Error<string>(ErrorMessage.Expected("end of input"));
 }

--- a/src/Parsley/Grammar.Fail.cs
+++ b/src/Parsley/Grammar.Fail.cs
@@ -2,5 +2,5 @@ namespace Parsley;
 
 public partial class Grammar<T>
 {
-    public static readonly Parser<T> Fail = (ref Text input) => new Error<T>(input.Position, ErrorMessage.Unknown());
+    public static readonly Parser<T> Fail = (ref Text input) => new Error<T>(ErrorMessage.Unknown());
 }

--- a/src/Parsley/Grammar.Keyword.cs
+++ b/src/Parsley/Grammar.Keyword.cs
@@ -17,11 +17,11 @@ partial class Grammar
                 {
                     input.Advance(word.Length);
 
-                    return new Parsed<string>(word, input.Position);
+                    return new Parsed<string>(word);
                 }
             }
 
-            return new Error<string>(input.Position, ErrorMessage.Expected(word));
+            return new Error<string>(ErrorMessage.Expected(word));
         };
     }
 }

--- a/src/Parsley/Grammar.Label.cs
+++ b/src/Parsley/Grammar.Label.cs
@@ -20,9 +20,9 @@ partial class Grammar
             if (start == newPosition)
             {
                 if (reply.Success)
-                    reply = new Parsed<T>(reply.Value, reply.Position, errors);
+                    reply = new Parsed<T>(reply.Value, errors);
                 else
-                    reply = new Error<T>(reply.Position, errors);
+                    reply = new Error<T>(errors);
             }
 
             return reply;

--- a/src/Parsley/Grammar.Operator.cs
+++ b/src/Parsley/Grammar.Operator.cs
@@ -12,10 +12,10 @@ partial class Grammar
             {
                 input.Advance(symbol.Length);
 
-                return new Parsed<string>(symbol, input.Position);
+                return new Parsed<string>(symbol);
             }
 
-            return new Error<string>(input.Position, ErrorMessage.Expected(symbol));
+            return new Error<string>(ErrorMessage.Expected(symbol));
         };
     }
 }

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -32,9 +32,9 @@ partial class Grammar
             //The item parser finally failed.
 
             if (oldPosition != newPosition)
-                return new Error<IEnumerable<T>>(reply.Position, reply.ErrorMessages);
+                return new Error<IEnumerable<T>>(reply.ErrorMessages);
 
-            return new Parsed<IEnumerable<T>>(list, reply.Position, reply.ErrorMessages);
+            return new Parsed<IEnumerable<T>>(list, reply.ErrorMessages);
         };
     }
 
@@ -79,10 +79,10 @@ partial class Grammar
             {
                 input.Advance(value.Length);
 
-                return new Parsed<string>(value.ToString(), input.Position);
+                return new Parsed<string>(value.ToString());
             }
 
-            return new Parsed<string>("", input.Position);
+            return new Parsed<string>("");
         };
     }
 
@@ -96,10 +96,10 @@ partial class Grammar
             {
                 input.Advance(value.Length);
 
-                return new Parsed<string>(value.ToString(), input.Position);
+                return new Parsed<string>(value.ToString());
             }
 
-            return new Error<string>(input.Position, ErrorMessage.Expected(name));
+            return new Error<string>(ErrorMessage.Expected(name));
         };
     }
 

--- a/src/Parsley/OperatorPrecedenceParser.cs
+++ b/src/Parsley/OperatorPrecedenceParser.cs
@@ -65,7 +65,7 @@ public class OperatorPrecedenceParser<T>
     Reply<T> Parse(ref Text input, int precedence)
     {
         if (!TryFindMatchingUnitParser(ref input, out var matchingUnitParser, out var token))
-            return new Error<T>(input.Position, ErrorMessage.Unknown());
+            return new Error<T>(ErrorMessage.Unknown());
 
         var reply = matchingUnitParser(ref input);
 

--- a/src/Parsley/Parsed.cs
+++ b/src/Parsley/Parsed.cs
@@ -2,18 +2,16 @@ namespace Parsley;
 
 public class Parsed<T> : Reply<T>
 {
-    public Parsed(T value, Position position)
-        :this(value, position, ErrorMessageList.Empty) { }
+    public Parsed(T value)
+        :this(value, ErrorMessageList.Empty) { }
 
-    public Parsed(T value, Position position, ErrorMessageList potentialErrors)
+    public Parsed(T value, ErrorMessageList potentialErrors)
     {
         Value = value;
-        Position = position;
         ErrorMessages = potentialErrors;
     }
 
     public T Value { get; }
-    public Position Position { get; }
     public bool Success => true;
     public ErrorMessageList ErrorMessages { get; }
 }

--- a/src/Parsley/ParserQuery.cs
+++ b/src/Parsley/ParserQuery.cs
@@ -12,7 +12,7 @@ public static class ParserQuery
     /// <param name="value">The value to treat as a parse result.</param>
     public static Parser<T> SucceedWithThisValue<T>(this T value)
     {
-        return (ref Text input) => new Parsed<T>(value, input.Position);
+        return (ref Text input) => new Parsed<T>(value);
     }
 
     /// <summary>
@@ -46,7 +46,7 @@ public static class ParserQuery
             if (reply.Success)
                 return constructNextParser(reply.Value)(ref input);
 
-            return new Error<U>(reply.Position, reply.ErrorMessages);
+            return new Error<U>(reply.ErrorMessages);
         };
     }
 }

--- a/src/Parsley/Reply.cs
+++ b/src/Parsley/Reply.cs
@@ -3,7 +3,6 @@ namespace Parsley;
 public interface Reply<out T>
 {
     T Value { get; }
-    Position Position { get; }
     bool Success { get; }
     ErrorMessageList ErrorMessages { get; }
 }


### PR DESCRIPTION
As part of a larger effort to repeatedly simplify the `Reply` types and *perhaps* do away with them entirely, this phases out its redundant `Position` property. `Position`s are already available when needed on the `Text` being traversed.

This property removal brings us closer to being able to dramatically reduce the number of objects constructed during a parsing operation, by making more of the many instances of `Reply` in fact immutable equivalent objects to those already constructed. They might become cachable, for instance, in future PRs.

While it's tempting to just aggressively delete the property and then chase compiler errors from there, here the commit history shows a safer approach. Knowing what compiler errors *would* have occurred, we "get ahead" of them one at a time by performing changes that would be sound on their own. By the time it gets to the commit that actually removes the property, that commit is trivial to create and review. This kept the system building and passing tests throughout development.