### PR TITLE
Define the Not(p) Parser

### DIFF
--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -178,6 +178,21 @@ class GrammarTests
         Attempt(AB).FailsToParse("A!", "A!", "B expected");
     }
 
+    public void NegatingAnotherParseRuleWithoutConsumingInput()
+    {
+        //When p succeeds, Not(p) fails.
+        //When p fails, Not(p) succeeds.
+        //Not(p) never consumes input, even if p fails after consuming input.
+
+        AB.Parses("AB").ShouldBe("AB");
+        AB.FailsToParse("A!", "!", "B expected");
+        AB.FailsToParse("BA", "BA", "A expected");
+
+        Not(AB).FailsToParse("AB", "AB", "parse failure expected");
+        Not(AB).PartiallyParses("A!", "A!").ShouldBe(Void.Value);
+        Not(AB).PartiallyParses("BA", "BA").ShouldBe(Void.Value);
+    }
+
     public void ImprovingDefaultMessagesWithAKnownExpectation()
     {
         var labeled = Label(AB, "'A' followed by 'B'");

--- a/src/Parsley/Grammar.Not.cs
+++ b/src/Parsley/Grammar.Not.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Parsley;
+
+partial class Grammar
+{
+    /// <summary>
+    /// The parser Not(p) succeeds when parser p fails, and fails
+    /// when parser p succeeds. Not(p) never consumes input.
+    /// </summary>
+    public static Parser<Void> Not<TValue>(Parser<TValue> parse)
+    {
+        return (ref ReadOnlySpan<char> input, ref Position position, [NotNullWhen(true)] out Void value, [NotNullWhen(false)] out string? expectation) =>
+        {
+            value = Void.Value;
+
+            var copyOfInput = input;
+            var copyOfPosition = position;
+
+            var succeeded = parse(ref copyOfInput, ref copyOfPosition, out _, out expectation);
+
+            if (succeeded)
+            {
+                expectation = "parse failure";
+                return false;
+            }
+
+            return true;
+        };
+    }
+}

--- a/src/Parsley/Void.cs
+++ b/src/Parsley/Void.cs
@@ -1,0 +1,12 @@
+namespace Parsley;
+
+/// <summary>
+/// Represents a void type, since `System.Void` is not valid everywhere a type name
+/// is required, such as for return types or generic type arguments.
+/// </summary>
+public readonly struct Void
+{
+    static readonly Void _value;
+
+    public static ref readonly Void Value => ref _value;
+}


### PR DESCRIPTION
Although look-aheads are discouraged, it can be useful to test that a given parser will not succeed at the current position before then confidently applying some secondary parser to take over from there.

* `Not(p)` succeeds when `p` fails.
* `Not(p)` fails when `p` succeeds.
* `Not(p)` never consumes input, even if `p` would.

Because there's no meaningful value to return on success, in conflict with the requirement that all succeeding parsers produce a value, we need a type similar to `System.Void` to act as a placeholder for an uninteresting-yet-necessary value. Although `System.Void` exists, it can only be used *some* places that other type names are valid. Unfortunately we cannot use `System.Void` here as we need a type that can be matched to a generic `<Tvalue>`; we can instead define our own `Parsley.Void` type and use it instead.

`Parsley.Void` is a value type with only one value, and no intersting properties. This keeps it low cost while satisfying the compiler, and lets us avoid resorting to nonidiomatic C# naming (functional languages often refer to this confusingly as a 'Unit' type despite there being a count of exactly zero units of anything worth counting):

```cs
public readonly struct Void
{
    static readonly Void _value;

    public static ref readonly Void Value => ref _value;
}
```

Here we reduce the chance of wasteful copies by using `ref` during accesses to the compiler-required meaningless value.