### PR TITLE
Generalize on Item Type

### DIFF
--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -70,7 +70,7 @@ class GrammarTests
 
         parser.FailsToParse("ABABA!", "!", "B expected");
 
-        var succeedWithThisValue = "ignored value".SucceedWithThisValue<string>();
+        var succeedWithThisValue = "ignored value".SucceedWithThisValue<char, string>();
         var infiniteLoop = () =>
         {
             ReadOnlySpan<char> input = "";
@@ -97,7 +97,7 @@ class GrammarTests
 
         parser.FailsToParse("ABABA!", "!", "B expected");
 
-        var succeedWithoutConsuming = "ignored value".SucceedWithThisValue<string>();
+        var succeedWithoutConsuming = "ignored value".SucceedWithThisValue<char, string>();
         var infiniteLoop = () =>
         {
             ReadOnlySpan<char> input = "";
@@ -206,7 +206,7 @@ class GrammarTests
         labeled.FailsToParse("A!", "!", "B expected");
 
         //When p succeeds but does not consume input, Label(p) still succeeds but the potential error is included.
-        var succeedWithoutConsuming = "$".SucceedWithThisValue<string>();
+        var succeedWithoutConsuming = "$".SucceedWithThisValue<char, string>();
         succeedWithoutConsuming
             .PartiallyParses("!", "!")
             .ShouldBe("$");

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -36,8 +36,8 @@ class GrammarTests
 
     public void CanDetectTheEndOfInputWithoutAdvancing()
     {
-        EndOfInput().Parses("").ShouldBe(Void.Value);
-        EndOfInput().FailsToParse("!", "!", "end of input expected");
+        EndOfInput<char>().Parses("").ShouldBe(Void.Value);
+        EndOfInput<char>().FailsToParse("!", "!", "end of input expected");
     }
 
     public void CanDemandThatAGivenParserRecognizesTheNextConsumableInput()

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -483,7 +483,7 @@ public class AlternationTests
 
     public void ChoosingRequiresAtLeastTwoParsersToChooseBetween()
     {
-        var attemptChoiceBetweenZeroAlternatives = () => Choice<string>();
+        var attemptChoiceBetweenZeroAlternatives = () => Choice<char, string>();
         attemptChoiceBetweenZeroAlternatives
             .ShouldThrow<ArgumentException>()
             .Message.ShouldBe("Choice requires at least two parsers to choose between. (Parameter 'parsers')");

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -36,8 +36,8 @@ class GrammarTests
 
     public void CanDetectTheEndOfInputWithoutAdvancing()
     {
-        EndOfInput.Parses("").ShouldBe("");
-        EndOfInput.FailsToParse("!", "!", "end of input expected");
+        EndOfInput().Parses("").ShouldBe("");
+        EndOfInput().FailsToParse("!", "!", "end of input expected");
     }
 
     public void CanDemandThatAGivenParserRecognizesTheNextConsumableInput()

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -36,7 +36,7 @@ class GrammarTests
 
     public void CanDetectTheEndOfInputWithoutAdvancing()
     {
-        EndOfInput().Parses("").ShouldBe("");
+        EndOfInput().Parses("").ShouldBe(Void.Value);
         EndOfInput().FailsToParse("!", "!", "end of input expected");
     }
 

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -70,7 +70,7 @@ class GrammarTests
 
         parser.FailsToParse("ABABA!", "!", "B expected");
 
-        var succeedWithThisValue = "ignored value".SucceedWithThisValue();
+        var succeedWithThisValue = "ignored value".SucceedWithThisValue<string>();
         var infiniteLoop = () =>
         {
             ReadOnlySpan<char> input = "";
@@ -97,7 +97,7 @@ class GrammarTests
 
         parser.FailsToParse("ABABA!", "!", "B expected");
 
-        var succeedWithoutConsuming = "ignored value".SucceedWithThisValue();
+        var succeedWithoutConsuming = "ignored value".SucceedWithThisValue<string>();
         var infiniteLoop = () =>
         {
             ReadOnlySpan<char> input = "";
@@ -206,7 +206,7 @@ class GrammarTests
         labeled.FailsToParse("A!", "!", "B expected");
 
         //When p succeeds but does not consume input, Label(p) still succeeds but the potential error is included.
-        var succeedWithoutConsuming = "$".SucceedWithThisValue();
+        var succeedWithoutConsuming = "$".SucceedWithThisValue<string>();
         succeedWithoutConsuming
             .PartiallyParses("!", "!")
             .ShouldBe("$");

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -11,8 +11,8 @@ class GrammarTests
         value = null;
         return false;
     };
-    static readonly Parser<char, char> Digit = Single(char.IsDigit, "Digit");
-    static readonly Parser<char, char> Letter = Single(char.IsLetter, "Letter");
+    static readonly Parser<char, char> Digit = Single<char>(char.IsDigit, "Digit");
+    static readonly Parser<char, char> Letter = Single<char>(char.IsLetter, "Letter");
 
     readonly Parser<char, char> A, B, COMMA;
     readonly Parser<char, string> AB;
@@ -358,9 +358,9 @@ class GrammarTests
 
     public void ProvidesConveniencePrimitiveRecognizingSingleNextItemSatisfyingSomePredicate()
     {
-        var lower = Single(char.IsLower, "Lowercase");
-        var upper = Single(char.IsUpper, "Uppercase");
-        var caseInsensitive = Single(char.IsLetter, "Case Insensitive");
+        var lower = Single<char>(char.IsLower, "Lowercase");
+        var upper = Single<char>(char.IsUpper, "Uppercase");
+        var caseInsensitive = Single<char>(char.IsLetter, "Case Insensitive");
 
         lower.FailsToParse("", "", "Lowercase expected");
 

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -5,17 +5,17 @@ namespace Parsley.Tests;
 
 class GrammarTests
 {
-    static readonly Parser<string> Fail = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
+    static readonly Parser_char_<string> Fail = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
     {
         expectation = "unsatisfiable expectation";
         value = null;
         return false;
     };
-    static readonly Parser<char> Digit = Single(char.IsDigit, "Digit");
-    static readonly Parser<char> Letter = Single(char.IsLetter, "Letter");
+    static readonly Parser_char_<char> Digit = Single(char.IsDigit, "Digit");
+    static readonly Parser_char_<char> Letter = Single(char.IsLetter, "Letter");
 
-    readonly Parser<char> A, B, COMMA;
-    readonly Parser<string> AB;
+    readonly Parser_char_<char> A, B, COMMA;
+    readonly Parser_char_<string> AB;
 
     public GrammarTests()
     {
@@ -472,7 +472,7 @@ class GrammarTests
 
 public class AlternationTests
 {
-    readonly Parser<string> A, B, C;
+    readonly Parser_char_<string> A, B, C;
 
     public AlternationTests()
     {
@@ -529,7 +529,7 @@ public class AlternationTests
         //consuming input. These tests simply describe the behavior under that
         //unusual situation.
 
-        Parser<string> succeedWithoutConsuming = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
+        Parser_char_<string> succeedWithoutConsuming = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
         {
             expectation = null;
             value = "atypical value";
@@ -541,7 +541,7 @@ public class AlternationTests
         Choice(A, succeedWithoutConsuming, B).Parses("").ShouldBe("atypical value");
     }
 
-    static readonly Parser<string> NeverExecuted =
+    static readonly Parser_char_<string> NeverExecuted =
         (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation)
             => throw new Exception("Parser 'NeverExecuted' should not have been executed.");
 }

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -5,17 +5,17 @@ namespace Parsley.Tests;
 
 class GrammarTests
 {
-    static readonly Parser_char_<string> Fail = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
+    static readonly Parser<char, string> Fail = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
     {
         expectation = "unsatisfiable expectation";
         value = null;
         return false;
     };
-    static readonly Parser_char_<char> Digit = Single(char.IsDigit, "Digit");
-    static readonly Parser_char_<char> Letter = Single(char.IsLetter, "Letter");
+    static readonly Parser<char, char> Digit = Single(char.IsDigit, "Digit");
+    static readonly Parser<char, char> Letter = Single(char.IsLetter, "Letter");
 
-    readonly Parser_char_<char> A, B, COMMA;
-    readonly Parser_char_<string> AB;
+    readonly Parser<char, char> A, B, COMMA;
+    readonly Parser<char, string> AB;
 
     public GrammarTests()
     {
@@ -472,7 +472,7 @@ class GrammarTests
 
 public class AlternationTests
 {
-    readonly Parser_char_<string> A, B, C;
+    readonly Parser<char, string> A, B, C;
 
     public AlternationTests()
     {
@@ -529,7 +529,7 @@ public class AlternationTests
         //consuming input. These tests simply describe the behavior under that
         //unusual situation.
 
-        Parser_char_<string> succeedWithoutConsuming = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
+        Parser<char, string> succeedWithoutConsuming = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
         {
             expectation = null;
             value = "atypical value";
@@ -541,7 +541,7 @@ public class AlternationTests
         Choice(A, succeedWithoutConsuming, B).Parses("").ShouldBe("atypical value");
     }
 
-    static readonly Parser_char_<string> NeverExecuted =
+    static readonly Parser<char, string> NeverExecuted =
         (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation)
             => throw new Exception("Parser 'NeverExecuted' should not have been executed.");
 }

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
@@ -5,10 +5,10 @@ namespace Parsley.Tests.IntegrationTests.Json;
 
 public class JsonGrammar
 {
-    public static readonly Parser<object?> JsonDocument;
+    public static readonly Parser_char_<object?> JsonDocument;
 
-    static readonly Parser<string> Whitespace = ZeroOrMore(char.IsWhiteSpace);
-    static readonly Parser<object?> Value = default!;
+    static readonly Parser_char_<string> Whitespace = ZeroOrMore(char.IsWhiteSpace);
+    static readonly Parser_char_<object?> Value = default!;
 
     static JsonGrammar()
     {
@@ -36,17 +36,17 @@ public class JsonGrammar
             select value;
     }
 
-    static Parser<object> Literal(string literal, object? value) =>
+    static Parser_char_<object> Literal(string literal, object? value) =>
         from x in Keyword(literal)
         select value;
 
-    static Parser<object> Array =>
+    static Parser_char_<object> Array =>
         from open in Operator("[")
         from items in ZeroOrMore(Value, Operator(","))
         from close in Operator("]")
         select (object) items.ToArray();
 
-    static Parser<object> Dictionary
+    static Parser_char_<object> Dictionary
     {
         get
         {
@@ -70,7 +70,7 @@ public class JsonGrammar
         }
     }
 
-    static Parser<object> Number
+    static Parser_char_<object> Number
     {
         get
         {
@@ -96,7 +96,7 @@ public class JsonGrammar
         }
     }
 
-    static Parser<string> Quote
+    static Parser_char_<string> Quote
     {
         get
         {

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
@@ -5,10 +5,10 @@ namespace Parsley.Tests.IntegrationTests.Json;
 
 public class JsonGrammar
 {
-    public static readonly Parser_char_<object?> JsonDocument;
+    public static readonly Parser<char, object?> JsonDocument;
 
-    static readonly Parser_char_<string> Whitespace = ZeroOrMore(char.IsWhiteSpace);
-    static readonly Parser_char_<object?> Value = default!;
+    static readonly Parser<char, string> Whitespace = ZeroOrMore(char.IsWhiteSpace);
+    static readonly Parser<char, object?> Value = default!;
 
     static JsonGrammar()
     {
@@ -36,17 +36,17 @@ public class JsonGrammar
             select value;
     }
 
-    static Parser_char_<object> Literal(string literal, object? value) =>
+    static Parser<char, object> Literal(string literal, object? value) =>
         from x in Keyword(literal)
         select value;
 
-    static Parser_char_<object> Array =>
+    static Parser<char, object> Array =>
         from open in Operator("[")
         from items in ZeroOrMore(Value, Operator(","))
         from close in Operator("]")
         select (object) items.ToArray();
 
-    static Parser_char_<object> Dictionary
+    static Parser<char, object> Dictionary
     {
         get
         {
@@ -70,7 +70,7 @@ public class JsonGrammar
         }
     }
 
-    static Parser_char_<object> Number
+    static Parser<char, object> Number
     {
         get
         {
@@ -96,7 +96,7 @@ public class JsonGrammar
         }
     }
 
-    static Parser_char_<string> Quote
+    static Parser<char, string> Quote
     {
         get
         {

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
@@ -32,7 +32,7 @@ public class JsonGrammar
 
         JsonDocument =
             from value in Value
-            from end in EndOfInput()
+            from end in EndOfInput<char>()
             select value;
     }
 

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
@@ -32,7 +32,7 @@ public class JsonGrammar
 
         JsonDocument =
             from value in Value
-            from end in EndOfInput
+            from end in EndOfInput()
             select value;
     }
 

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
@@ -84,8 +84,8 @@ public class JsonGrammar
                     select dot + digits)
 
                 from optionalExponent in Optional(
-                    from e in Single(x => x is 'e' or 'E', "exponent")
-                    from sign in Optional(Single(x => x is '+' or '-', "sign").Select(x => x.ToString()))
+                    from e in Single<char>(x => x is 'e' or 'E', "exponent")
+                    from sign in Optional(Single<char>(x => x is '+' or '-', "sign").Select(x => x.ToString()))
                     from digits in Digits
                     select $"{e}{sign}{digits}")
 
@@ -100,7 +100,7 @@ public class JsonGrammar
     {
         get
         {
-            var LetterOrDigit = Single(char.IsLetterOrDigit, "letter or digit");
+            var LetterOrDigit = Single<char>(char.IsLetterOrDigit, "letter or digit");
 
             return
                 from open in Single('"')
@@ -108,7 +108,7 @@ public class JsonGrammar
                     Choice(
                         from slash in Single('\\')
                         from unescaped in Choice(
-                            from escape in Single(c => "\"\\bfnrt/".Contains(c), "escape character")
+                            from escape in Single<char>(c => "\"\\bfnrt/".Contains(c), "escape character")
                             select $"{escape}"
                                 .Replace("\"", "\"")
                                 .Replace("\\", "\\")
@@ -130,7 +130,7 @@ public class JsonGrammar
                                     CultureInfo.InvariantCulture))
                         )
                         select unescaped,
-                        Single(c => c != '"' && c != '\\', "non-quote, not-slash character").Select(x => x.ToString())
+                        Single<char>(c => c != '"' && c != '\\', "non-quote, not-slash character").Select(x => x.ToString())
                     ))
                 from close in Single('"')
                 select string.Join("", content);

--- a/src/Parsley.Tests/OperatorPrecedenceParserTests.cs
+++ b/src/Parsley.Tests/OperatorPrecedenceParserTests.cs
@@ -119,18 +119,18 @@ class OperatorPrecedenceParserTests
         value.ToString().ShouldBe(expectedTree);
     }
 
-    static readonly Parser<string> Digit = from c in Single(char.IsDigit, "Digit") select c.ToString();
-    static readonly Parser<string> Name = OneOrMore(char.IsLetter, "Name");
-    static readonly Parser<string> Increment = Operator("++");
-    static readonly Parser<string> Decrement = Operator("--");
-    static readonly Parser<string> Add = Operator("+");
-    static readonly Parser<string> Subtract = Operator("-");
-    static readonly Parser<string> Multiply = Operator("*");
-    static readonly Parser<string> Divide = Operator("/");
-    static readonly Parser<string> Exponent = Operator("^");
-    static readonly Parser<string> LeftParen = Operator("(");
-    static readonly Parser<string> RightParen = Operator(")");
-    static readonly Parser<string> Comma = Operator(",");
+    static readonly Parser_char_<string> Digit = from c in Single(char.IsDigit, "Digit") select c.ToString();
+    static readonly Parser_char_<string> Name = OneOrMore(char.IsLetter, "Name");
+    static readonly Parser_char_<string> Increment = Operator("++");
+    static readonly Parser_char_<string> Decrement = Operator("--");
+    static readonly Parser_char_<string> Add = Operator("+");
+    static readonly Parser_char_<string> Subtract = Operator("-");
+    static readonly Parser_char_<string> Multiply = Operator("*");
+    static readonly Parser_char_<string> Divide = Operator("/");
+    static readonly Parser_char_<string> Exponent = Operator("^");
+    static readonly Parser_char_<string> LeftParen = Operator("(");
+    static readonly Parser_char_<string> RightParen = Operator(")");
+    static readonly Parser_char_<string> Comma = Operator(",");
 
     interface IExpression
     {

--- a/src/Parsley.Tests/OperatorPrecedenceParserTests.cs
+++ b/src/Parsley.Tests/OperatorPrecedenceParserTests.cs
@@ -119,18 +119,18 @@ class OperatorPrecedenceParserTests
         value.ToString().ShouldBe(expectedTree);
     }
 
-    static readonly Parser_char_<string> Digit = from c in Single(char.IsDigit, "Digit") select c.ToString();
-    static readonly Parser_char_<string> Name = OneOrMore(char.IsLetter, "Name");
-    static readonly Parser_char_<string> Increment = Operator("++");
-    static readonly Parser_char_<string> Decrement = Operator("--");
-    static readonly Parser_char_<string> Add = Operator("+");
-    static readonly Parser_char_<string> Subtract = Operator("-");
-    static readonly Parser_char_<string> Multiply = Operator("*");
-    static readonly Parser_char_<string> Divide = Operator("/");
-    static readonly Parser_char_<string> Exponent = Operator("^");
-    static readonly Parser_char_<string> LeftParen = Operator("(");
-    static readonly Parser_char_<string> RightParen = Operator(")");
-    static readonly Parser_char_<string> Comma = Operator(",");
+    static readonly Parser<char, string> Digit = from c in Single(char.IsDigit, "Digit") select c.ToString();
+    static readonly Parser<char, string> Name = OneOrMore(char.IsLetter, "Name");
+    static readonly Parser<char, string> Increment = Operator("++");
+    static readonly Parser<char, string> Decrement = Operator("--");
+    static readonly Parser<char, string> Add = Operator("+");
+    static readonly Parser<char, string> Subtract = Operator("-");
+    static readonly Parser<char, string> Multiply = Operator("*");
+    static readonly Parser<char, string> Divide = Operator("/");
+    static readonly Parser<char, string> Exponent = Operator("^");
+    static readonly Parser<char, string> LeftParen = Operator("(");
+    static readonly Parser<char, string> RightParen = Operator(")");
+    static readonly Parser<char, string> Comma = Operator(",");
 
     interface IExpression
     {

--- a/src/Parsley.Tests/OperatorPrecedenceParserTests.cs
+++ b/src/Parsley.Tests/OperatorPrecedenceParserTests.cs
@@ -119,7 +119,7 @@ class OperatorPrecedenceParserTests
         value.ToString().ShouldBe(expectedTree);
     }
 
-    static readonly Parser<char, string> Digit = from c in Single(char.IsDigit, "Digit") select c.ToString();
+    static readonly Parser<char, string> Digit = from c in Single<char>(char.IsDigit, "Digit") select c.ToString();
     static readonly Parser<char, string> Name = OneOrMore(char.IsLetter, "Name");
     static readonly Parser<char, string> Increment = Operator("++");
     static readonly Parser<char, string> Decrement = Operator("--");

--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -6,7 +6,7 @@ namespace Parsley.Tests;
 
 class ParserQueryTests
 {
-    static readonly Parser<char, char> Next = Single(_ => true, "character");
+    static readonly Parser<char, char> Next = Single<char>(_ => true, "character");
 
     static readonly Parser<char, string> Fail = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
     {

--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -6,9 +6,9 @@ namespace Parsley.Tests;
 
 class ParserQueryTests
 {
-    static readonly Parser<char> Next = Single(_ => true, "character");
+    static readonly Parser_char_<char> Next = Single(_ => true, "character");
 
-    static readonly Parser<string> Fail = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
+    static readonly Parser_char_<string> Fail = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
     {
         expectation = "unsatisfiable expectation";
         value = null;

--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -6,9 +6,9 @@ namespace Parsley.Tests;
 
 class ParserQueryTests
 {
-    static readonly Parser_char_<char> Next = Single(_ => true, "character");
+    static readonly Parser<char, char> Next = Single(_ => true, "character");
 
-    static readonly Parser_char_<string> Fail = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
+    static readonly Parser<char, string> Fail = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
     {
         expectation = "unsatisfiable expectation";
         value = null;

--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -17,7 +17,7 @@ class ParserQueryTests
 
     public void CanBuildParserWhichSimulatesSuccessfulParsingOfGivenValueWithoutConsumingInput()
     {
-        var parser = 1.SucceedWithThisValue<int>();
+        var parser = 1.SucceedWithThisValue<char, int>();
 
         parser.PartiallyParses("input", "input").ShouldBe(1);
     }

--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -17,7 +17,7 @@ class ParserQueryTests
 
     public void CanBuildParserWhichSimulatesSuccessfulParsingOfGivenValueWithoutConsumingInput()
     {
-        var parser = 1.SucceedWithThisValue();
+        var parser = 1.SucceedWithThisValue<int>();
 
         parser.PartiallyParses("input", "input").ShouldBe(1);
     }

--- a/src/Parsley.Tests/ReadOnlySpanExtensionsTests.cs
+++ b/src/Parsley.Tests/ReadOnlySpanExtensionsTests.cs
@@ -85,5 +85,14 @@ class ReadOnlySpanExtensionsTests
         abc123.TakeWhile(6, digits).ToString().ShouldBe("");
         abc123.TakeWhile(6, letters).ToString().ShouldBe("");
         abc123.TakeWhile(6, alphanumerics).ToString().ShouldBe("");
+
+        ReadOnlySpan<int> numbers = new[] { 2, 4, 6, 8, 1, 3, 5, 7, 9 };
+
+        numbers.TakeWhile(0, x => x % 2 == 0).ToArray().ShouldBe(new[] { 2, 4, 6, 8 });
+        numbers.TakeWhile(1, x => x % 2 == 0).ToArray().ShouldBe(new[] { 4, 6, 8 });
+        numbers.TakeWhile(2, x => x % 2 == 0).ToArray().ShouldBe(new[] { 6, 8 });
+        numbers.TakeWhile(3, x => x % 2 == 0).ToArray().ShouldBe(new[] { 8 });
+        numbers.TakeWhile(4, x => x % 2 == 0).ToArray().ShouldBe(Array.Empty<int>());
+        numbers.TakeWhile(9, x => x % 2 == 0).ToArray().ShouldBe(Array.Empty<int>());
     }
 }

--- a/src/Parsley.Tests/ReadOnlySpanExtensionsTests.cs
+++ b/src/Parsley.Tests/ReadOnlySpanExtensionsTests.cs
@@ -32,6 +32,31 @@ class ReadOnlySpanExtensionsTests
         abc.Peek(3, 1).ToString().ShouldBe("");
         abc.Peek(3, 2).ToString().ShouldBe("");
         abc.Peek(3, 100).ToString().ShouldBe("");
+
+        ReadOnlySpan<int> digits = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+        digits.Peek(0, 0).ToArray().ShouldBe(Array.Empty<int>());
+        digits.Peek(0, 1).ToArray().ShouldBe(new[] { 0 });
+        digits.Peek(0, 2).ToArray().ShouldBe(new[] { 0, 1 });
+        digits.Peek(0, 3).ToArray().ShouldBe(new[] { 0, 1, 2 });
+        digits.Peek(0, 4).ToArray().ShouldBe(new[] { 0, 1, 2, 3 });
+        digits.Peek(0, 9).ToArray().ShouldBe(new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 });
+        digits.Peek(0, 10).ToArray().ShouldBe(new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+        digits.Peek(0, 100).ToArray().ShouldBe(new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+
+        digits.Peek(6, 0).ToArray().ShouldBe(Array.Empty<int>());
+        digits.Peek(6, 1).ToArray().ShouldBe(new[] { 6 });
+        digits.Peek(6, 2).ToArray().ShouldBe(new[] { 6, 7 });
+        digits.Peek(6, 3).ToArray().ShouldBe(new[] { 6, 7, 8 });
+        digits.Peek(6, 4).ToArray().ShouldBe(new[] { 6, 7, 8, 9 });
+        digits.Peek(6, 100).ToArray().ShouldBe(new[] { 6, 7, 8, 9 });
+
+        digits.Peek(10, 0).ToArray().ShouldBe(Array.Empty<int>());
+        digits.Peek(10, 1).ToArray().ShouldBe(Array.Empty<int>());
+        digits.Peek(10, 2).ToArray().ShouldBe(Array.Empty<int>());
+        digits.Peek(10, 3).ToArray().ShouldBe(Array.Empty<int>());
+        digits.Peek(10, 4).ToArray().ShouldBe(Array.Empty<int>());
+        digits.Peek(10, 100).ToArray().ShouldBe(Array.Empty<int>());
     }
 
     public void CanMatchLeadingItemsByPredicate()

--- a/src/Parsley/Assertions.cs
+++ b/src/Parsley/Assertions.cs
@@ -5,7 +5,7 @@ namespace Parsley;
 
 public static class Assertions
 {
-    public static void FailsToParse<TValue>(this Parser_char_<TValue> parse, string input, string expectedUnparsedInput, string expectedMessage)
+    public static void FailsToParse<TValue>(this Parser<char, TValue> parse, string input, string expectedUnparsedInput, string expectedMessage)
     {
         ReadOnlySpan<char> inputSpan = input;
         int index = 0;
@@ -24,7 +24,7 @@ public static class Assertions
             inputSpan.LeavingUnparsedInput(index, expectedUnparsedInput);
     }
 
-    public static TValue PartiallyParses<TValue>(this Parser_char_<TValue> parse, string input, string expectedUnparsedInput)
+    public static TValue PartiallyParses<TValue>(this Parser<char, TValue> parse, string input, string expectedUnparsedInput)
     {
         ReadOnlySpan<char> inputSpan = input;
         int index = 0;
@@ -40,7 +40,7 @@ public static class Assertions
         return value;
     }
 
-    public static TValue Parses<TValue>(this Parser_char_<TValue> parse, string input)
+    public static TValue Parses<TValue>(this Parser<char, TValue> parse, string input)
     {
         ReadOnlySpan<char> inputSpan = input;
         int index = 0;

--- a/src/Parsley/Assertions.cs
+++ b/src/Parsley/Assertions.cs
@@ -5,7 +5,7 @@ namespace Parsley;
 
 public static class Assertions
 {
-    public static void FailsToParse<TValue>(this Parser<TValue> parse, string input, string expectedUnparsedInput, string expectedMessage)
+    public static void FailsToParse<TValue>(this Parser_char_<TValue> parse, string input, string expectedUnparsedInput, string expectedMessage)
     {
         ReadOnlySpan<char> inputSpan = input;
         int index = 0;
@@ -24,7 +24,7 @@ public static class Assertions
             inputSpan.LeavingUnparsedInput(index, expectedUnparsedInput);
     }
 
-    public static TValue PartiallyParses<TValue>(this Parser<TValue> parse, string input, string expectedUnparsedInput)
+    public static TValue PartiallyParses<TValue>(this Parser_char_<TValue> parse, string input, string expectedUnparsedInput)
     {
         ReadOnlySpan<char> inputSpan = input;
         int index = 0;
@@ -40,7 +40,7 @@ public static class Assertions
         return value;
     }
 
-    public static TValue Parses<TValue>(this Parser<TValue> parse, string input)
+    public static TValue Parses<TValue>(this Parser_char_<TValue> parse, string input)
     {
         ReadOnlySpan<char> inputSpan = input;
         int index = 0;

--- a/src/Parsley/Grammar.Attempt.cs
+++ b/src/Parsley/Grammar.Attempt.cs
@@ -9,7 +9,7 @@ partial class Grammar
     /// that it hasn't consumed any input when an error occurs. This combinator
     /// is used whenever arbitrary look ahead is needed.
     /// </summary>
-    public static Parser_char_<TValue> Attempt<TValue>(Parser_char_<TValue> parse)
+    public static Parser<char, TValue> Attempt<TValue>(Parser<char, TValue> parse)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out TValue? value, [NotNullWhen(false)] out string? expectation) =>
         {

--- a/src/Parsley/Grammar.Attempt.cs
+++ b/src/Parsley/Grammar.Attempt.cs
@@ -9,7 +9,7 @@ partial class Grammar
     /// that it hasn't consumed any input when an error occurs. This combinator
     /// is used whenever arbitrary look ahead is needed.
     /// </summary>
-    public static Parser<TValue> Attempt<TValue>(Parser<TValue> parse)
+    public static Parser_char_<TValue> Attempt<TValue>(Parser_char_<TValue> parse)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out TValue? value, [NotNullWhen(false)] out string? expectation) =>
         {

--- a/src/Parsley/Grammar.Attempt.cs
+++ b/src/Parsley/Grammar.Attempt.cs
@@ -9,9 +9,9 @@ partial class Grammar
     /// that it hasn't consumed any input when an error occurs. This combinator
     /// is used whenever arbitrary look ahead is needed.
     /// </summary>
-    public static Parser<char, TValue> Attempt<TValue>(Parser<char, TValue> parse)
+    public static Parser<TItem, TValue> Attempt<TItem, TValue>(Parser<TItem, TValue> parse)
     {
-        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out TValue? value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out TValue? value, [NotNullWhen(false)] out string? expectation) =>
         {
             var originalIndex = index;
 

--- a/src/Parsley/Grammar.Choice.cs
+++ b/src/Parsley/Grammar.Choice.cs
@@ -25,13 +25,13 @@ partial class Grammar
     /// implementation of the parser combinators and the generation
     /// of good error messages.
     /// </summary>
-    public static Parser<char, TValue> Choice<TValue>(params Parser<char, TValue>[] parsers)
+    public static Parser<TItem, TValue> Choice<TItem, TValue>(params Parser<TItem, TValue>[] parsers)
     {
         if (parsers.Length <= 1)
             throw new ArgumentException(
                 $"{nameof(Choice)} requires at least two parsers to choose between.", nameof(parsers));
 
-        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out TValue? value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out TValue? value, [NotNullWhen(false)] out string? expectation) =>
         {
             var originalIndex = index;
 

--- a/src/Parsley/Grammar.Choice.cs
+++ b/src/Parsley/Grammar.Choice.cs
@@ -25,7 +25,7 @@ partial class Grammar
     /// implementation of the parser combinators and the generation
     /// of good error messages.
     /// </summary>
-    public static Parser<TValue> Choice<TValue>(params Parser<TValue>[] parsers)
+    public static Parser_char_<TValue> Choice<TValue>(params Parser_char_<TValue>[] parsers)
     {
         if (parsers.Length <= 1)
             throw new ArgumentException(

--- a/src/Parsley/Grammar.Choice.cs
+++ b/src/Parsley/Grammar.Choice.cs
@@ -25,7 +25,7 @@ partial class Grammar
     /// implementation of the parser combinators and the generation
     /// of good error messages.
     /// </summary>
-    public static Parser_char_<TValue> Choice<TValue>(params Parser_char_<TValue>[] parsers)
+    public static Parser<char, TValue> Choice<TValue>(params Parser<char, TValue>[] parsers)
     {
         if (parsers.Length <= 1)
             throw new ArgumentException(

--- a/src/Parsley/Grammar.EndOfInput.cs
+++ b/src/Parsley/Grammar.EndOfInput.cs
@@ -4,18 +4,22 @@ namespace Parsley;
 
 partial class Grammar
 {
-    public static readonly Parser<char, string> EndOfInput =
-        (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
+    public static Parser<char, string> EndOfInput()
+    {
+        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
         {
             if (index == input.Length)
             {
                 expectation = null;
                 value = "";
+
                 return true;
             }
 
             expectation = "end of input";
             value = null;
+
             return false;
         };
+    }
 }

--- a/src/Parsley/Grammar.EndOfInput.cs
+++ b/src/Parsley/Grammar.EndOfInput.cs
@@ -4,9 +4,9 @@ namespace Parsley;
 
 partial class Grammar
 {
-    public static Parser<char, Void> EndOfInput()
+    public static Parser<TItem, Void> EndOfInput<TItem>()
     {
-        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out Void value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out Void value, [NotNullWhen(false)] out string? expectation) =>
         {
             value = Void.Value;
 

--- a/src/Parsley/Grammar.EndOfInput.cs
+++ b/src/Parsley/Grammar.EndOfInput.cs
@@ -4,7 +4,7 @@ namespace Parsley;
 
 partial class Grammar
 {
-    public static readonly Parser_char_<string> EndOfInput =
+    public static readonly Parser<char, string> EndOfInput =
         (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
         {
             if (index == input.Length)

--- a/src/Parsley/Grammar.EndOfInput.cs
+++ b/src/Parsley/Grammar.EndOfInput.cs
@@ -4,20 +4,20 @@ namespace Parsley;
 
 partial class Grammar
 {
-    public static Parser<char, string> EndOfInput()
+    public static Parser<char, Void> EndOfInput()
     {
-        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out Void value, [NotNullWhen(false)] out string? expectation) =>
         {
+            value = Void.Value;
+
             if (index == input.Length)
             {
                 expectation = null;
-                value = "";
 
                 return true;
             }
 
             expectation = "end of input";
-            value = null;
 
             return false;
         };

--- a/src/Parsley/Grammar.EndOfInput.cs
+++ b/src/Parsley/Grammar.EndOfInput.cs
@@ -4,7 +4,7 @@ namespace Parsley;
 
 partial class Grammar
 {
-    public static readonly Parser<string> EndOfInput =
+    public static readonly Parser_char_<string> EndOfInput =
         (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
         {
             if (index == input.Length)

--- a/src/Parsley/Grammar.Keyword.cs
+++ b/src/Parsley/Grammar.Keyword.cs
@@ -4,7 +4,7 @@ namespace Parsley;
 
 partial class Grammar
 {
-    public static Parser_char_<string> Keyword(string word)
+    public static Parser<char, string> Keyword(string word)
     {
         if (word.Any(ch => !char.IsLetter(ch)))
             throw new ArgumentException("Keywords may only contain letters.", nameof(word));

--- a/src/Parsley/Grammar.Keyword.cs
+++ b/src/Parsley/Grammar.Keyword.cs
@@ -4,7 +4,7 @@ namespace Parsley;
 
 partial class Grammar
 {
-    public static Parser<string> Keyword(string word)
+    public static Parser_char_<string> Keyword(string word)
     {
         if (word.Any(ch => !char.IsLetter(ch)))
             throw new ArgumentException("Keywords may only contain letters.", nameof(word));

--- a/src/Parsley/Grammar.Label.cs
+++ b/src/Parsley/Grammar.Label.cs
@@ -9,7 +9,7 @@ partial class Grammar
     /// When parser p does not consume any input, Label(p, l) is the same
     /// as p, except any messages are replaced with expectation label l.
     /// </summary>
-    public static Parser<TValue> Label<TValue>(Parser<TValue> parse, string label)
+    public static Parser_char_<TValue> Label<TValue>(Parser_char_<TValue> parse, string label)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out TValue? value, [NotNullWhen(false)] out string? expectation) =>
         {

--- a/src/Parsley/Grammar.Label.cs
+++ b/src/Parsley/Grammar.Label.cs
@@ -9,7 +9,7 @@ partial class Grammar
     /// When parser p does not consume any input, Label(p, l) is the same
     /// as p, except any messages are replaced with expectation label l.
     /// </summary>
-    public static Parser_char_<TValue> Label<TValue>(Parser_char_<TValue> parse, string label)
+    public static Parser<char, TValue> Label<TValue>(Parser<char, TValue> parse, string label)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out TValue? value, [NotNullWhen(false)] out string? expectation) =>
         {

--- a/src/Parsley/Grammar.Label.cs
+++ b/src/Parsley/Grammar.Label.cs
@@ -9,9 +9,9 @@ partial class Grammar
     /// When parser p does not consume any input, Label(p, l) is the same
     /// as p, except any messages are replaced with expectation label l.
     /// </summary>
-    public static Parser<char, TValue> Label<TValue>(Parser<char, TValue> parse, string label)
+    public static Parser<TItem, TValue> Label<TItem, TValue>(Parser<TItem, TValue> parse, string label)
     {
-        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out TValue? value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out TValue? value, [NotNullWhen(false)] out string? expectation) =>
         {
             var originalIndex = index;
 

--- a/src/Parsley/Grammar.Not.cs
+++ b/src/Parsley/Grammar.Not.cs
@@ -8,7 +8,7 @@ partial class Grammar
     /// The parser Not(p) succeeds when parser p fails, and fails
     /// when parser p succeeds. Not(p) never consumes input.
     /// </summary>
-    public static Parser<Void> Not<TValue>(Parser<TValue> parse)
+    public static Parser_char_<Void> Not<TValue>(Parser_char_<TValue> parse)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out Void value, [NotNullWhen(false)] out string? expectation) =>
         {

--- a/src/Parsley/Grammar.Not.cs
+++ b/src/Parsley/Grammar.Not.cs
@@ -8,7 +8,7 @@ partial class Grammar
     /// The parser Not(p) succeeds when parser p fails, and fails
     /// when parser p succeeds. Not(p) never consumes input.
     /// </summary>
-    public static Parser_char_<Void> Not<TValue>(Parser_char_<TValue> parse)
+    public static Parser<char, Void> Not<TValue>(Parser<char, TValue> parse)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out Void value, [NotNullWhen(false)] out string? expectation) =>
         {

--- a/src/Parsley/Grammar.Not.cs
+++ b/src/Parsley/Grammar.Not.cs
@@ -8,9 +8,9 @@ partial class Grammar
     /// The parser Not(p) succeeds when parser p fails, and fails
     /// when parser p succeeds. Not(p) never consumes input.
     /// </summary>
-    public static Parser<char, Void> Not<TValue>(Parser<char, TValue> parse)
+    public static Parser<TItem, Void> Not<TItem, TValue>(Parser<TItem, TValue> parse)
     {
-        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out Void value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out Void value, [NotNullWhen(false)] out string? expectation) =>
         {
             value = Void.Value;
 

--- a/src/Parsley/Grammar.Operator.cs
+++ b/src/Parsley/Grammar.Operator.cs
@@ -4,7 +4,7 @@ namespace Parsley;
 
 partial class Grammar
 {
-    public static Parser<string> Operator(string symbol)
+    public static Parser_char_<string> Operator(string symbol)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
         {

--- a/src/Parsley/Grammar.Operator.cs
+++ b/src/Parsley/Grammar.Operator.cs
@@ -4,7 +4,7 @@ namespace Parsley;
 
 partial class Grammar
 {
-    public static Parser_char_<string> Operator(string symbol)
+    public static Parser<char, string> Operator(string symbol)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
         {

--- a/src/Parsley/Grammar.Optional.cs
+++ b/src/Parsley/Grammar.Optional.cs
@@ -11,7 +11,7 @@ public static partial class Grammar
     public static Parser<char, TValue?> Optional<TValue>(Parser<char, TValue> parser)
         where TValue : class
     {
-        var nothing = default(TValue).SucceedWithThisValue();
+        var nothing = default(TValue).SucceedWithThisValue<TValue?>();
         return Choice(
             from x in parser
             select (TValue?)x, nothing);
@@ -27,7 +27,7 @@ public static partial class Grammar
     public static Parser<char, TValue?> Optional<TValue>(Parser<char, TValue> parser, TValue? ignoredOverloadResolver = null)
         where TValue : struct
     {
-        var nothing = default(TValue?).SucceedWithThisValue();
+        var nothing = default(TValue?).SucceedWithThisValue<TValue?>();
         return Choice(parser.Select(x => (TValue?)x), nothing);
     }
 }

--- a/src/Parsley/Grammar.Optional.cs
+++ b/src/Parsley/Grammar.Optional.cs
@@ -8,7 +8,7 @@ public static partial class Grammar
     /// Optional(p) is equivalent to p whenever p succeeds or when p fails after consuming input.
     /// If p fails without consuming input, Optional(p) succeeds.
     /// </summary>
-    public static Parser<TValue?> Optional<TValue>(Parser<TValue> parser)
+    public static Parser_char_<TValue?> Optional<TValue>(Parser_char_<TValue> parser)
         where TValue : class
     {
         var nothing = default(TValue).SucceedWithThisValue();
@@ -24,7 +24,7 @@ public static partial class Grammar
     [SuppressMessage("ReSharper", "MethodOverloadWithOptionalParameter",
         Justification = "This warning is inaccurate. The other `struct` " +
                         "overload does not in fact hide this one.")]
-    public static Parser<TValue?> Optional<TValue>(Parser<TValue> parser, TValue? ignoredOverloadResolver = null)
+    public static Parser_char_<TValue?> Optional<TValue>(Parser_char_<TValue> parser, TValue? ignoredOverloadResolver = null)
         where TValue : struct
     {
         var nothing = default(TValue?).SucceedWithThisValue();

--- a/src/Parsley/Grammar.Optional.cs
+++ b/src/Parsley/Grammar.Optional.cs
@@ -11,7 +11,7 @@ public static partial class Grammar
     public static Parser<char, TValue?> Optional<TValue>(Parser<char, TValue> parser)
         where TValue : class
     {
-        var nothing = default(TValue).SucceedWithThisValue<TValue?>();
+        var nothing = default(TValue).SucceedWithThisValue<char, TValue?>();
         return Choice(
             from x in parser
             select (TValue?)x, nothing);
@@ -27,7 +27,7 @@ public static partial class Grammar
     public static Parser<char, TValue?> Optional<TValue>(Parser<char, TValue> parser, TValue? ignoredOverloadResolver = null)
         where TValue : struct
     {
-        var nothing = default(TValue?).SucceedWithThisValue<TValue?>();
+        var nothing = default(TValue?).SucceedWithThisValue<char, TValue?>();
         return Choice(parser.Select(x => (TValue?)x), nothing);
     }
 }

--- a/src/Parsley/Grammar.Optional.cs
+++ b/src/Parsley/Grammar.Optional.cs
@@ -8,10 +8,10 @@ public static partial class Grammar
     /// Optional(p) is equivalent to p whenever p succeeds or when p fails after consuming input.
     /// If p fails without consuming input, Optional(p) succeeds.
     /// </summary>
-    public static Parser<char, TValue?> Optional<TValue>(Parser<char, TValue> parser)
+    public static Parser<TItem, TValue?> Optional<TItem, TValue>(Parser<TItem, TValue> parser)
         where TValue : class
     {
-        var nothing = default(TValue).SucceedWithThisValue<char, TValue?>();
+        var nothing = default(TValue).SucceedWithThisValue<TItem, TValue?>();
         return Choice(
             from x in parser
             select (TValue?)x, nothing);
@@ -24,10 +24,10 @@ public static partial class Grammar
     [SuppressMessage("ReSharper", "MethodOverloadWithOptionalParameter",
         Justification = "This warning is inaccurate. The other `struct` " +
                         "overload does not in fact hide this one.")]
-    public static Parser<char, TValue?> Optional<TValue>(Parser<char, TValue> parser, TValue? ignoredOverloadResolver = null)
+    public static Parser<TItem, TValue?> Optional<TItem, TValue>(Parser<TItem, TValue> parser, TValue? ignoredOverloadResolver = null)
         where TValue : struct
     {
-        var nothing = default(TValue?).SucceedWithThisValue<char, TValue?>();
+        var nothing = default(TValue?).SucceedWithThisValue<TItem, TValue?>();
         return Choice(parser.Select(x => (TValue?)x), nothing);
     }
 }

--- a/src/Parsley/Grammar.Optional.cs
+++ b/src/Parsley/Grammar.Optional.cs
@@ -8,7 +8,7 @@ public static partial class Grammar
     /// Optional(p) is equivalent to p whenever p succeeds or when p fails after consuming input.
     /// If p fails without consuming input, Optional(p) succeeds.
     /// </summary>
-    public static Parser_char_<TValue?> Optional<TValue>(Parser_char_<TValue> parser)
+    public static Parser<char, TValue?> Optional<TValue>(Parser<char, TValue> parser)
         where TValue : class
     {
         var nothing = default(TValue).SucceedWithThisValue();
@@ -24,7 +24,7 @@ public static partial class Grammar
     [SuppressMessage("ReSharper", "MethodOverloadWithOptionalParameter",
         Justification = "This warning is inaccurate. The other `struct` " +
                         "overload does not in fact hide this one.")]
-    public static Parser_char_<TValue?> Optional<TValue>(Parser_char_<TValue> parser, TValue? ignoredOverloadResolver = null)
+    public static Parser<char, TValue?> Optional<TValue>(Parser<char, TValue> parser, TValue? ignoredOverloadResolver = null)
         where TValue : struct
     {
         var nothing = default(TValue?).SucceedWithThisValue();

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -118,7 +118,7 @@ partial class Grammar
 
     static Parser<char, IEnumerable<TValue>> Zero<TValue>()
     {
-        return Enumerable.Empty<TValue>().SucceedWithThisValue<IEnumerable<TValue>>();
+        return Enumerable.Empty<TValue>().SucceedWithThisValue<char, IEnumerable<TValue>>();
     }
 
     static IEnumerable<T> List<T>(T first, IEnumerable<T> rest)

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -10,7 +10,7 @@ partial class Grammar
     /// end of the sequence, p must fail without consuming input, otherwise the
     /// sequence will fail with the error reported by p.
     /// </summary>
-    public static Parser<IEnumerable<TValue>> ZeroOrMore<TValue>(Parser<TValue> item)
+    public static Parser_char_<IEnumerable<TValue>> ZeroOrMore<TValue>(Parser_char_<TValue> item)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out IEnumerable<TValue>? values, [NotNullWhen(false)] out string? expectation) =>
         {
@@ -46,7 +46,7 @@ partial class Grammar
     /// <summary>
     /// OneOrMore(p) behaves like ZeroOrMore(p), except that p must succeed at least one time.
     /// </summary>
-    public static Parser<IEnumerable<TValue>> OneOrMore<TValue>(Parser<TValue> item)
+    public static Parser_char_<IEnumerable<TValue>> OneOrMore<TValue>(Parser_char_<TValue> item)
     {
         return from first in item
             from rest in ZeroOrMore(item)
@@ -57,7 +57,7 @@ partial class Grammar
     /// ZeroOrMore(p, s) parses zero or more occurrences of p separated by occurrences of s,
     /// returning the list of values returned by successful applications of p.
     /// </summary>
-    public static Parser<IEnumerable<TItem>> ZeroOrMore<TItem, S>(Parser<TItem> item, Parser<S> separator)
+    public static Parser_char_<IEnumerable<TItem>> ZeroOrMore<TItem, S>(Parser_char_<TItem> item, Parser_char_<S> separator)
     {
         return Choice(OneOrMore(item, separator), Zero<TItem>());
     }
@@ -65,7 +65,7 @@ partial class Grammar
     /// <summary>
     /// OneOrMore(p, s) behaves like ZeroOrMore(p, s), except that p must succeed at least one time.
     /// </summary>
-    public static Parser<IEnumerable<TValue>> OneOrMore<TValue, S>(Parser<TValue> item, Parser<S> separator)
+    public static Parser_char_<IEnumerable<TValue>> OneOrMore<TValue, S>(Parser_char_<TValue> item, Parser_char_<S> separator)
     {
         return from first in item
             from rest in ZeroOrMore(from sep in separator
@@ -74,7 +74,7 @@ partial class Grammar
             select List(first, rest);
     }
 
-    public static Parser<string> ZeroOrMore(Predicate<char> test)
+    public static Parser_char_<string> ZeroOrMore(Predicate<char> test)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
         {
@@ -95,7 +95,7 @@ partial class Grammar
         };
     }
 
-    public static Parser<string> OneOrMore(Predicate<char> test, string name)
+    public static Parser_char_<string> OneOrMore(Predicate<char> test, string name)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
         {
@@ -116,7 +116,7 @@ partial class Grammar
         };
     }
 
-    static Parser<IEnumerable<TValue>> Zero<TValue>()
+    static Parser_char_<IEnumerable<TValue>> Zero<TValue>()
     {
         return Enumerable.Empty<TValue>().SucceedWithThisValue();
     }

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -10,9 +10,9 @@ partial class Grammar
     /// end of the sequence, p must fail without consuming input, otherwise the
     /// sequence will fail with the error reported by p.
     /// </summary>
-    public static Parser<char, IEnumerable<TValue>> ZeroOrMore<TValue>(Parser<char, TValue> item)
+    public static Parser<TItem, IEnumerable<TValue>> ZeroOrMore<TItem, TValue>(Parser<TItem, TValue> item)
     {
-        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out IEnumerable<TValue>? values, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out IEnumerable<TValue>? values, [NotNullWhen(false)] out string? expectation) =>
         {
             var oldIndex = index;
             string? itemExpectation;
@@ -46,7 +46,7 @@ partial class Grammar
     /// <summary>
     /// OneOrMore(p) behaves like ZeroOrMore(p), except that p must succeed at least one time.
     /// </summary>
-    public static Parser<char, IEnumerable<TValue>> OneOrMore<TValue>(Parser<char, TValue> item)
+    public static Parser<TItem, IEnumerable<TValue>> OneOrMore<TItem, TValue>(Parser<TItem, TValue> item)
     {
         return from first in item
             from rest in ZeroOrMore(item)
@@ -57,15 +57,15 @@ partial class Grammar
     /// ZeroOrMore(p, s) parses zero or more occurrences of p separated by occurrences of s,
     /// returning the list of values returned by successful applications of p.
     /// </summary>
-    public static Parser<char, IEnumerable<TItem>> ZeroOrMore<TItem, S>(Parser<char, TItem> item, Parser<char, S> separator)
+    public static Parser<TItem, IEnumerable<TValue>> ZeroOrMore<TItem, TValue, S>(Parser<TItem, TValue> item, Parser<TItem, S> separator)
     {
-        return Choice(OneOrMore(item, separator), Zero<TItem>());
+        return Choice(OneOrMore(item, separator), Zero<TItem, TValue>());
     }
 
     /// <summary>
     /// OneOrMore(p, s) behaves like ZeroOrMore(p, s), except that p must succeed at least one time.
     /// </summary>
-    public static Parser<char, IEnumerable<TValue>> OneOrMore<TValue, S>(Parser<char, TValue> item, Parser<char, S> separator)
+    public static Parser<TItem, IEnumerable<TValue>> OneOrMore<TItem, TValue, S>(Parser<TItem, TValue> item, Parser<TItem, S> separator)
     {
         return from first in item
             from rest in ZeroOrMore(from sep in separator
@@ -116,9 +116,9 @@ partial class Grammar
         };
     }
 
-    static Parser<char, IEnumerable<TValue>> Zero<TValue>()
+    static Parser<TItem, IEnumerable<TValue>> Zero<TItem, TValue>()
     {
-        return Enumerable.Empty<TValue>().SucceedWithThisValue<char, IEnumerable<TValue>>();
+        return Enumerable.Empty<TValue>().SucceedWithThisValue<TItem, IEnumerable<TValue>>();
     }
 
     static IEnumerable<T> List<T>(T first, IEnumerable<T> rest)

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -10,7 +10,7 @@ partial class Grammar
     /// end of the sequence, p must fail without consuming input, otherwise the
     /// sequence will fail with the error reported by p.
     /// </summary>
-    public static Parser_char_<IEnumerable<TValue>> ZeroOrMore<TValue>(Parser_char_<TValue> item)
+    public static Parser<char, IEnumerable<TValue>> ZeroOrMore<TValue>(Parser<char, TValue> item)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out IEnumerable<TValue>? values, [NotNullWhen(false)] out string? expectation) =>
         {
@@ -46,7 +46,7 @@ partial class Grammar
     /// <summary>
     /// OneOrMore(p) behaves like ZeroOrMore(p), except that p must succeed at least one time.
     /// </summary>
-    public static Parser_char_<IEnumerable<TValue>> OneOrMore<TValue>(Parser_char_<TValue> item)
+    public static Parser<char, IEnumerable<TValue>> OneOrMore<TValue>(Parser<char, TValue> item)
     {
         return from first in item
             from rest in ZeroOrMore(item)
@@ -57,7 +57,7 @@ partial class Grammar
     /// ZeroOrMore(p, s) parses zero or more occurrences of p separated by occurrences of s,
     /// returning the list of values returned by successful applications of p.
     /// </summary>
-    public static Parser_char_<IEnumerable<TItem>> ZeroOrMore<TItem, S>(Parser_char_<TItem> item, Parser_char_<S> separator)
+    public static Parser<char, IEnumerable<TItem>> ZeroOrMore<TItem, S>(Parser<char, TItem> item, Parser<char, S> separator)
     {
         return Choice(OneOrMore(item, separator), Zero<TItem>());
     }
@@ -65,7 +65,7 @@ partial class Grammar
     /// <summary>
     /// OneOrMore(p, s) behaves like ZeroOrMore(p, s), except that p must succeed at least one time.
     /// </summary>
-    public static Parser_char_<IEnumerable<TValue>> OneOrMore<TValue, S>(Parser_char_<TValue> item, Parser_char_<S> separator)
+    public static Parser<char, IEnumerable<TValue>> OneOrMore<TValue, S>(Parser<char, TValue> item, Parser<char, S> separator)
     {
         return from first in item
             from rest in ZeroOrMore(from sep in separator
@@ -74,7 +74,7 @@ partial class Grammar
             select List(first, rest);
     }
 
-    public static Parser_char_<string> ZeroOrMore(Predicate<char> test)
+    public static Parser<char, string> ZeroOrMore(Predicate<char> test)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
         {
@@ -95,7 +95,7 @@ partial class Grammar
         };
     }
 
-    public static Parser_char_<string> OneOrMore(Predicate<char> test, string name)
+    public static Parser<char, string> OneOrMore(Predicate<char> test, string name)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
         {
@@ -116,7 +116,7 @@ partial class Grammar
         };
     }
 
-    static Parser_char_<IEnumerable<TValue>> Zero<TValue>()
+    static Parser<char, IEnumerable<TValue>> Zero<TValue>()
     {
         return Enumerable.Empty<TValue>().SucceedWithThisValue();
     }

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -118,7 +118,7 @@ partial class Grammar
 
     static Parser<char, IEnumerable<TValue>> Zero<TValue>()
     {
-        return Enumerable.Empty<TValue>().SucceedWithThisValue();
+        return Enumerable.Empty<TValue>().SucceedWithThisValue<IEnumerable<TValue>>();
     }
 
     static IEnumerable<T> List<T>(T first, IEnumerable<T> rest)

--- a/src/Parsley/Grammar.Single.cs
+++ b/src/Parsley/Grammar.Single.cs
@@ -4,12 +4,12 @@ namespace Parsley;
 
 partial class Grammar
 {
-    public static Parser_char_<char> Single(char expected)
+    public static Parser<char, char> Single(char expected)
     {
         return Single(x => x == expected, expected.ToString());
     }
 
-    public static Parser_char_<char> Single(Predicate<char> test, string name)
+    public static Parser<char, char> Single(Predicate<char> test, string name)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out char value, [NotNullWhen(false)] out string? expectation) =>
         {

--- a/src/Parsley/Grammar.Single.cs
+++ b/src/Parsley/Grammar.Single.cs
@@ -4,20 +4,20 @@ namespace Parsley;
 
 partial class Grammar
 {
-    public static Parser<char, char> Single(char expected)
+    public static Parser<TItem, TItem> Single<TItem>(TItem expected)
     {
-        return Single(x => x == expected, expected.ToString());
+        return Single<TItem>(x => EqualityComparer<TItem>.Default.Equals(x, expected), $"{expected}");
     }
 
-    public static Parser<char, char> Single(Predicate<char> test, string name)
+    public static Parser<TItem, TItem> Single<TItem>(Predicate<TItem> test, string name)
     {
-        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out char value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out TItem? value, [NotNullWhen(false)] out string? expectation) =>
         {
             var next = input.Peek(index, 1);
 
             if (next.Length == 1)
             {
-                char c = next[0];
+                var c = next[0]!;
                 if (test(c))
                 {
                     index += 1;

--- a/src/Parsley/Grammar.Single.cs
+++ b/src/Parsley/Grammar.Single.cs
@@ -4,12 +4,12 @@ namespace Parsley;
 
 partial class Grammar
 {
-    public static Parser<char> Single(char expected)
+    public static Parser_char_<char> Single(char expected)
     {
         return Single(x => x == expected, expected.ToString());
     }
 
-    public static Parser<char> Single(Predicate<char> test, string name)
+    public static Parser_char_<char> Single(Predicate<char> test, string name)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out char value, [NotNullWhen(false)] out string? expectation) =>
         {

--- a/src/Parsley/OperatorPrecedenceParser.cs
+++ b/src/Parsley/OperatorPrecedenceParser.cs
@@ -2,7 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Parsley;
 
-public delegate Parser<TValue> ExtendParserBuilder<TValue>(TValue left);
+public delegate Parser_char_<TValue> ExtendParserBuilder<TValue>(TValue left);
 public delegate TValue AtomNodeBuilder<out TValue>(string atom);
 public delegate TValue UnaryNodeBuilder<TValue>(string symbol, TValue operand);
 public delegate TValue BinaryNodeBuilder<TValue>(TValue left, string symbol, TValue right);
@@ -10,39 +10,39 @@ public enum Associativity { Left, Right }
 
 public class OperatorPrecedenceParser<TValue>
 {
-    readonly List<(Parser<string>, Parser<TValue>)> unitParsers = new();
-    readonly List<(Parser<string>, int precedence, ExtendParserBuilder<TValue>)> extendParsers = new();
+    readonly List<(Parser_char_<string>, Parser_char_<TValue>)> unitParsers = new();
+    readonly List<(Parser_char_<string>, int precedence, ExtendParserBuilder<TValue>)> extendParsers = new();
 
-    public void Unit(Parser<string> kind, Parser<TValue> unitParser)
+    public void Unit(Parser_char_<string> kind, Parser_char_<TValue> unitParser)
     {
         unitParsers.Add((kind, unitParser));
     }
 
-    public void Atom(Parser<string> kind, AtomNodeBuilder<TValue> createAtomNode)
+    public void Atom(Parser_char_<string> kind, AtomNodeBuilder<TValue> createAtomNode)
     {
         Unit(kind, from token in kind
             select createAtomNode(token));
     }
 
-    public void Prefix(Parser<string> operation, int precedence, UnaryNodeBuilder<TValue> createUnaryNode)
+    public void Prefix(Parser_char_<string> operation, int precedence, UnaryNodeBuilder<TValue> createUnaryNode)
     {
         Unit(operation, from symbol in operation
             from operand in OperandAtPrecedenceLevel(precedence)
             select createUnaryNode(symbol, operand));
     }
 
-    public void Extend(Parser<string> operation, int precedence, ExtendParserBuilder<TValue> createExtendParser)
+    public void Extend(Parser_char_<string> operation, int precedence, ExtendParserBuilder<TValue> createExtendParser)
     {
         extendParsers.Add((operation, precedence, createExtendParser));
     }
 
-    public void Postfix(Parser<string> operation, int precedence, UnaryNodeBuilder<TValue> createUnaryNode)
+    public void Postfix(Parser_char_<string> operation, int precedence, UnaryNodeBuilder<TValue> createUnaryNode)
     {
         Extend(operation, precedence, left => from symbol in operation
             select createUnaryNode(symbol, left));
     }
 
-    public void Binary(Parser<string> operation, int precedence, BinaryNodeBuilder<TValue> createBinaryNode,
+    public void Binary(Parser_char_<string> operation, int precedence, BinaryNodeBuilder<TValue> createBinaryNode,
                        Associativity associativity = Associativity.Left)
     {
         int rightOperandPrecedence = precedence;
@@ -55,11 +55,11 @@ public class OperatorPrecedenceParser<TValue>
             select createBinaryNode(left, symbol, right));
     }
 
-    public Parser<TValue> Parser
+    public Parser_char_<TValue> Parser
         => (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out TValue? value, [NotNullWhen(false)] out string? expectation)
                 => Parse(input, ref index, 0, out value, out expectation);
 
-    Parser<TValue> OperandAtPrecedenceLevel(int precedence)
+    Parser_char_<TValue> OperandAtPrecedenceLevel(int precedence)
         => (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out TValue? value, [NotNullWhen(false)] out string? expectation)
             => Parse(input, ref index, precedence, out value, out expectation);
 
@@ -92,7 +92,7 @@ public class OperatorPrecedenceParser<TValue>
         return false;
     }
 
-    bool TryFindMatchingUnitParser(ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out Parser<TValue>? found, out string? token)
+    bool TryFindMatchingUnitParser(ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out Parser_char_<TValue>? found, out string? token)
     {
         found = null;
         token = null;

--- a/src/Parsley/Parser.cs
+++ b/src/Parsley/Parser.cs
@@ -2,7 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Parsley;
 
-public delegate bool Parser<TValue>(
+public delegate bool Parser_char_<TValue>(
     ReadOnlySpan<char> input,
     ref int index,
     [NotNullWhen(true)] out TValue? value,

--- a/src/Parsley/Parser.cs
+++ b/src/Parsley/Parser.cs
@@ -2,12 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Parsley;
 
-public delegate bool Parser_char_<TValue>(
-    ReadOnlySpan<char> input,
-    ref int index,
-    [NotNullWhen(true)] out TValue? value,
-    [NotNullWhen(false)] out string? expectation);
-
 public delegate bool Parser<TItem, TValue>(
     ReadOnlySpan<TItem> input,
     ref int index,

--- a/src/Parsley/Parser.cs
+++ b/src/Parsley/Parser.cs
@@ -2,7 +2,14 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Parsley;
 
-public delegate bool Parser<TValue>(ReadOnlySpan<char> input,
-                                    ref int index,
-                                    [NotNullWhen(true)] out TValue? value,
-                                    [NotNullWhen(false)] out string? expectation);
+public delegate bool Parser<TValue>(
+    ReadOnlySpan<char> input,
+    ref int index,
+    [NotNullWhen(true)] out TValue? value,
+    [NotNullWhen(false)] out string? expectation);
+
+public delegate bool Parser<TItem, TValue>(
+    ReadOnlySpan<TItem> input,
+    ref int index,
+    [NotNullWhen(true)] out TValue? value,
+    [NotNullWhen(false)] out string? expectation);

--- a/src/Parsley/ParserQuery.cs
+++ b/src/Parsley/ParserQuery.cs
@@ -26,17 +26,17 @@ public static class ParserQuery
     /// <summary>
     /// Allows LINQ syntax to construct a new parser from a simpler parser, using a single 'from' clause.
     /// </summary>
-    public static Parser<char, U> Select<T, U>(this Parser<char, T> parser, Func<T, U> constructResult)
+    public static Parser<TItem, U> Select<TItem, T, U>(this Parser<TItem, T> parser, Func<T, U> constructResult)
     {
-        return parser.Bind(t => constructResult(t).SucceedWithThisValue<char, U>());
+        return parser.Bind(t => constructResult(t).SucceedWithThisValue<TItem, U>());
     }
 
     /// <summary>
     /// Allows LINQ syntax to construct a new parser from an ordered sequence of simpler parsers, using multiple 'from' clauses.
     /// </summary>
-    public static Parser<char, V> SelectMany<T, U, V>(this Parser<char, T> parser, Func<T, Parser<char, U>> k, Func<T, U, V> s)
+    public static Parser<TItem, V> SelectMany<TItem, T, U, V>(this Parser<TItem, T> parser, Func<T, Parser<TItem, U>> k, Func<T, U, V> s)
     {
-        return parser.Bind(x => k(x).Bind(y => s(x, y).SucceedWithThisValue<char, V>()));
+        return parser.Bind(x => k(x).Bind(y => s(x, y).SucceedWithThisValue<TItem, V>()));
     }
 
     /// <summary>
@@ -45,9 +45,9 @@ public static class ParserQuery
     /// <remarks>
     /// In monadic terms, this is the 'Bind' function.
     /// </remarks>
-    static Parser<char, U> Bind<T, U>(this Parser<char, T> parse, Func<T, Parser<char, U>> constructNextParser)
+    static Parser<TItem, U> Bind<TItem, T, U>(this Parser<TItem, T> parse, Func<T, Parser<TItem, U>> constructNextParser)
     {
-        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out U? uValue, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out U? uValue, [NotNullWhen(false)] out string? expectation) =>
         {
             if (parse(input, ref index, out var tValue, out expectation))
                 return constructNextParser(tValue)(input, ref index, out uValue, out expectation);

--- a/src/Parsley/ParserQuery.cs
+++ b/src/Parsley/ParserQuery.cs
@@ -12,7 +12,7 @@ public static class ParserQuery
     /// </remarks>
     /// <typeparam name="TValue">The type of the value to treat as a parse result.</typeparam>
     /// <param name="value">The value to treat as a parse result.</param>
-    public static Parser_char_<TValue> SucceedWithThisValue<TValue>(this TValue value)
+    public static Parser<char, TValue> SucceedWithThisValue<TValue>(this TValue value)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out TValue? succeedingValue, [NotNullWhen(false)] out string? expectation) =>
         {
@@ -25,7 +25,7 @@ public static class ParserQuery
     /// <summary>
     /// Allows LINQ syntax to construct a new parser from a simpler parser, using a single 'from' clause.
     /// </summary>
-    public static Parser_char_<U> Select<T, U>(this Parser_char_<T> parser, Func<T, U> constructResult)
+    public static Parser<char, U> Select<T, U>(this Parser<char, T> parser, Func<T, U> constructResult)
     {
         return parser.Bind(t => constructResult(t).SucceedWithThisValue());
     }
@@ -33,7 +33,7 @@ public static class ParserQuery
     /// <summary>
     /// Allows LINQ syntax to construct a new parser from an ordered sequence of simpler parsers, using multiple 'from' clauses.
     /// </summary>
-    public static Parser_char_<V> SelectMany<T, U, V>(this Parser_char_<T> parser, Func<T, Parser_char_<U>> k, Func<T, U, V> s)
+    public static Parser<char, V> SelectMany<T, U, V>(this Parser<char, T> parser, Func<T, Parser<char, U>> k, Func<T, U, V> s)
     {
         return parser.Bind(x => k(x).Bind(y => s(x, y).SucceedWithThisValue()));
     }
@@ -44,7 +44,7 @@ public static class ParserQuery
     /// <remarks>
     /// In monadic terms, this is the 'Bind' function.
     /// </remarks>
-    static Parser_char_<U> Bind<T, U>(this Parser_char_<T> parse, Func<T, Parser_char_<U>> constructNextParser)
+    static Parser<char, U> Bind<T, U>(this Parser<char, T> parse, Func<T, Parser<char, U>> constructNextParser)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out U? uValue, [NotNullWhen(false)] out string? expectation) =>
         {

--- a/src/Parsley/ParserQuery.cs
+++ b/src/Parsley/ParserQuery.cs
@@ -27,7 +27,7 @@ public static class ParserQuery
     /// </summary>
     public static Parser<char, U> Select<T, U>(this Parser<char, T> parser, Func<T, U> constructResult)
     {
-        return parser.Bind(t => constructResult(t).SucceedWithThisValue());
+        return parser.Bind(t => constructResult(t).SucceedWithThisValue<U>());
     }
 
     /// <summary>
@@ -35,7 +35,7 @@ public static class ParserQuery
     /// </summary>
     public static Parser<char, V> SelectMany<T, U, V>(this Parser<char, T> parser, Func<T, Parser<char, U>> k, Func<T, U, V> s)
     {
-        return parser.Bind(x => k(x).Bind(y => s(x, y).SucceedWithThisValue()));
+        return parser.Bind(x => k(x).Bind(y => s(x, y).SucceedWithThisValue<V>()));
     }
 
     /// <summary>

--- a/src/Parsley/ParserQuery.cs
+++ b/src/Parsley/ParserQuery.cs
@@ -10,11 +10,12 @@ public static class ParserQuery
     /// <remarks>
     /// In monadic terms, this is the 'Unit' function.
     /// </remarks>
+    /// <typeparam name="TItem">The type of the items in the span being traversed.</typeparam>
     /// <typeparam name="TValue">The type of the value to treat as a parse result.</typeparam>
     /// <param name="value">The value to treat as a parse result.</param>
-    public static Parser<char, TValue> SucceedWithThisValue<TValue>(this TValue value)
+    public static Parser<TItem, TValue> SucceedWithThisValue<TItem, TValue>(this TValue value)
     {
-        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out TValue? succeedingValue, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out TValue? succeedingValue, [NotNullWhen(false)] out string? expectation) =>
         {
             expectation = null;
             succeedingValue = value!;
@@ -27,7 +28,7 @@ public static class ParserQuery
     /// </summary>
     public static Parser<char, U> Select<T, U>(this Parser<char, T> parser, Func<T, U> constructResult)
     {
-        return parser.Bind(t => constructResult(t).SucceedWithThisValue<U>());
+        return parser.Bind(t => constructResult(t).SucceedWithThisValue<char, U>());
     }
 
     /// <summary>
@@ -35,7 +36,7 @@ public static class ParserQuery
     /// </summary>
     public static Parser<char, V> SelectMany<T, U, V>(this Parser<char, T> parser, Func<T, Parser<char, U>> k, Func<T, U, V> s)
     {
-        return parser.Bind(x => k(x).Bind(y => s(x, y).SucceedWithThisValue<V>()));
+        return parser.Bind(x => k(x).Bind(y => s(x, y).SucceedWithThisValue<char, V>()));
     }
 
     /// <summary>

--- a/src/Parsley/ParserQuery.cs
+++ b/src/Parsley/ParserQuery.cs
@@ -12,7 +12,7 @@ public static class ParserQuery
     /// </remarks>
     /// <typeparam name="TValue">The type of the value to treat as a parse result.</typeparam>
     /// <param name="value">The value to treat as a parse result.</param>
-    public static Parser<TValue> SucceedWithThisValue<TValue>(this TValue value)
+    public static Parser_char_<TValue> SucceedWithThisValue<TValue>(this TValue value)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out TValue? succeedingValue, [NotNullWhen(false)] out string? expectation) =>
         {
@@ -25,7 +25,7 @@ public static class ParserQuery
     /// <summary>
     /// Allows LINQ syntax to construct a new parser from a simpler parser, using a single 'from' clause.
     /// </summary>
-    public static Parser<U> Select<T, U>(this Parser<T> parser, Func<T, U> constructResult)
+    public static Parser_char_<U> Select<T, U>(this Parser_char_<T> parser, Func<T, U> constructResult)
     {
         return parser.Bind(t => constructResult(t).SucceedWithThisValue());
     }
@@ -33,7 +33,7 @@ public static class ParserQuery
     /// <summary>
     /// Allows LINQ syntax to construct a new parser from an ordered sequence of simpler parsers, using multiple 'from' clauses.
     /// </summary>
-    public static Parser<V> SelectMany<T, U, V>(this Parser<T> parser, Func<T, Parser<U>> k, Func<T, U, V> s)
+    public static Parser_char_<V> SelectMany<T, U, V>(this Parser_char_<T> parser, Func<T, Parser_char_<U>> k, Func<T, U, V> s)
     {
         return parser.Bind(x => k(x).Bind(y => s(x, y).SucceedWithThisValue()));
     }
@@ -44,7 +44,7 @@ public static class ParserQuery
     /// <remarks>
     /// In monadic terms, this is the 'Bind' function.
     /// </remarks>
-    static Parser<U> Bind<T, U>(this Parser<T> parse, Func<T, Parser<U>> constructNextParser)
+    static Parser_char_<U> Bind<T, U>(this Parser_char_<T> parse, Func<T, Parser_char_<U>> constructNextParser)
     {
         return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out U? uValue, [NotNullWhen(false)] out string? expectation) =>
         {

--- a/src/Parsley/ReadOnlySpanExtensions.cs
+++ b/src/Parsley/ReadOnlySpanExtensions.cs
@@ -7,7 +7,7 @@ public static class ReadOnlySpanExtensions
             ? input.Slice(index)
             : input.Slice(index, length);
 
-    public static ReadOnlySpan<char> TakeWhile(this ReadOnlySpan<char> input, int index, Predicate<char> test)
+    public static ReadOnlySpan<T> TakeWhile<T>(this ReadOnlySpan<T> input, int index, Predicate<T> test)
     {
         int i = 0;
 

--- a/src/Parsley/ReadOnlySpanExtensions.cs
+++ b/src/Parsley/ReadOnlySpanExtensions.cs
@@ -2,7 +2,7 @@ namespace Parsley;
 
 public static class ReadOnlySpanExtensions
 {
-    public static ReadOnlySpan<char> Peek(this ReadOnlySpan<char> input, int index, int length)
+    public static ReadOnlySpan<T> Peek<T>(this ReadOnlySpan<T> input, int index, int length)
         => index + length > input.Length
             ? input.Slice(index)
             : input.Slice(index, length);


### PR DESCRIPTION
Prior to this PR, all parsing was limited to processing `ReadOnlySpan<char>` (and in practice such a span providing efficient inspection of an original string to parse). Here, we generalize to any item type for the span being parsed.

Before:

```cs
public delegate bool Parser<TValue>(
    ReadOnlySpan<char> input,
    ref int index,
    [NotNullWhen(true)] out TValue? value,
    [NotNullWhen(false)] out string? expectation);
```

After

```cs
public delegate bool Parser<TItem, TValue>(
    ReadOnlySpan<TItem> input,
    ref int index,
    [NotNullWhen(true)] out TValue? value,
    [NotNullWhen(false)] out string? expectation);
```

To easily apply such a change systemwide, the following technique was used:

1. Beside the original `Parser` declaration, create a distinct `Parser` declaration with the desired two type parameters. At this moment, it was unused.
2. Rename the original single-type-argument `Parser<TValue>` to `Parser_char_<TValue>`, preparing us for a swift and unambiguous search/replace in step 3.
3. Perform a global plain text search/replace of `Parser_char_<` with `Parser<char, ` and drop the single-type-argument delegate type. This has the effect of making all parser declarations flip from the original delegate type to the new one in one step, without having to manually adjust each in turn, and without having to chase compiler error messages for an extended period of time.
4. Visit each parser-building method one at a type, introducing a new `TItem` for each occurrence of a previously-assumed `char`.

The system was building and passing all tests at each step.