### PR TITLE
Efficient repetition primitives

### DIFF
--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -147,25 +147,35 @@ class GrammarTests
         var parser = ZeroOrMore(AB, AND);
 
         parser.Parses("").ShouldBeEmpty();
+        parser.PartiallyParses("&", "&").ShouldBeEmpty();
+
+        parser.FailsToParse("A", "", "B expected");
+        parser.FailsToParse("A&", "&", "B expected");
         parser.Parses("AB").Single().ShouldBe("AB");
-        parser.Parses("AB&&AB").ShouldBe(new[] { "AB", "AB" });
-        parser.Parses("AB&&AB&&AB").ShouldBe(new[] { "AB", "AB", "AB" });
-        parser.PartiallyParses("AB&&AB&&ABA", "A").ShouldBe(new[] { "AB", "AB", "AB" });
         parser.FailsToParse("AB&", "", "& expected");
         parser.FailsToParse("AB&&", "", "A expected");
         parser.FailsToParse("AB&&A", "", "B expected");
+        parser.Parses("AB&&AB").ShouldBe(new[] { "AB", "AB" });
+        parser.Parses("AB&&AB&&AB").ShouldBe(new[] { "AB", "AB", "AB" });
+        parser.PartiallyParses("AB&&AB&&ABA", "A").ShouldBe(new[] { "AB", "AB", "AB" });
     }
 
     public void ApplyingARuleOneOrMoreTimesInterspersedByASeparatorRule()
     {
-        var parser = OneOrMore(AB, COMMA);
+        var parser = OneOrMore(AB, AND);
 
         parser.FailsToParse("", "", "A expected");
+        parser.FailsToParse("&", "&", "A expected");
+
+        parser.FailsToParse("A", "", "B expected");
+        parser.FailsToParse("A&", "&", "B expected");
         parser.Parses("AB").Single().ShouldBe("AB");
-        parser.Parses("AB,AB").ShouldBe(new[] { "AB", "AB" });
-        parser.Parses("AB,AB,AB").ShouldBe(new[] { "AB", "AB", "AB" });
-        parser.FailsToParse("AB,", "", "A expected");
-        parser.FailsToParse("AB,A", "", "B expected");
+        parser.FailsToParse("AB&", "", "& expected");
+        parser.FailsToParse("AB&&", "", "A expected");
+        parser.FailsToParse("AB&&A", "", "B expected");
+        parser.Parses("AB&&AB").ShouldBe(new[] { "AB", "AB" });
+        parser.Parses("AB&&AB&&AB").ShouldBe(new[] { "AB", "AB", "AB" });
+        parser.PartiallyParses("AB&&AB&&ABA", "A").ShouldBe(new[] { "AB", "AB", "AB" });
     }
 
     public void ParsingAnOptionalRuleZeroOrOneTimes()

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -200,13 +200,5 @@ partial class Grammar
     {
         return Enumerable.Empty<TValue>().SucceedWithThisValue<TItem, IEnumerable<TValue>>();
     }
-
-    static IEnumerable<T> List<T>(T first, IEnumerable<T> rest)
-    {
-        yield return first;
-
-        foreach (var item in rest)
-            yield return item;
-    }
 }
 

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -56,6 +56,37 @@ partial class Grammar
         };
     }
 
+    /// <summary>
+    /// OneOrMore(p) behaves like ZeroOrMore(p), except that p must succeed at least one time.
+    /// </summary>
+    public static Parser<TItem, IEnumerable<TValue>> OneOrMore<TItem, TValue>(Parser<TItem, TValue> item)
+    {
+        return from first in item
+            from rest in ZeroOrMore(item)
+            select List(first, rest);
+    }
+
+    /// <summary>
+    /// ZeroOrMore(p, s) parses zero or more occurrences of p separated by occurrences of s,
+    /// returning the list of values returned by successful applications of p.
+    /// </summary>
+    public static Parser<TItem, IEnumerable<TValue>> ZeroOrMore<TItem, TValue, S>(Parser<TItem, TValue> item, Parser<TItem, S> separator)
+    {
+        return Choice(OneOrMore(item, separator), Zero<TItem, TValue>());
+    }
+
+    /// <summary>
+    /// OneOrMore(p, s) behaves like ZeroOrMore(p, s), except that p must succeed at least one time.
+    /// </summary>
+    public static Parser<TItem, IEnumerable<TValue>> OneOrMore<TItem, TValue, S>(Parser<TItem, TValue> item, Parser<TItem, S> separator)
+    {
+        return from first in item
+            from rest in ZeroOrMore(from sep in separator
+                from next in item
+                select next)
+            select List(first, rest);
+    }
+
     static bool Repeat<TItem, TValue>(List<TValue> accumulator,
                                       Parser<TItem, TValue> item,
                                       ReadOnlySpan<TItem> input,
@@ -88,37 +119,6 @@ partial class Grammar
         expectation = null;
         values = accumulator;
         return true;
-    }
-
-    /// <summary>
-    /// OneOrMore(p) behaves like ZeroOrMore(p), except that p must succeed at least one time.
-    /// </summary>
-    public static Parser<TItem, IEnumerable<TValue>> OneOrMore<TItem, TValue>(Parser<TItem, TValue> item)
-    {
-        return from first in item
-            from rest in ZeroOrMore(item)
-            select List(first, rest);
-    }
-
-    /// <summary>
-    /// ZeroOrMore(p, s) parses zero or more occurrences of p separated by occurrences of s,
-    /// returning the list of values returned by successful applications of p.
-    /// </summary>
-    public static Parser<TItem, IEnumerable<TValue>> ZeroOrMore<TItem, TValue, S>(Parser<TItem, TValue> item, Parser<TItem, S> separator)
-    {
-        return Choice(OneOrMore(item, separator), Zero<TItem, TValue>());
-    }
-
-    /// <summary>
-    /// OneOrMore(p, s) behaves like ZeroOrMore(p, s), except that p must succeed at least one time.
-    /// </summary>
-    public static Parser<TItem, IEnumerable<TValue>> OneOrMore<TItem, TValue, S>(Parser<TItem, TValue> item, Parser<TItem, S> separator)
-    {
-        return from first in item
-            from rest in ZeroOrMore(from sep in separator
-                from next in item
-                select next)
-            select List(first, rest);
     }
 
     public static Parser<char, string> ZeroOrMore(Func<char, bool> test)

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -52,14 +52,14 @@ partial class Grammar
         {
             var oldIndex = index;
             string? itemExpectation;
-            var list = new List<TValue>();
+            var accumulator = new List<TValue>();
 
             while (item(input, ref index, out var itemValue, out itemExpectation))
             {
                 if (oldIndex == index)
                     throw new Exception($"Parser encountered a potential infinite loop at index {index}.");
 
-                list.Add(itemValue);
+                accumulator.Add(itemValue);
 
                 oldIndex = index;
             }
@@ -74,7 +74,7 @@ partial class Grammar
             }
 
             expectation = null;
-            values = list;
+            values = accumulator;
             return true;
         };
     }

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -52,31 +52,31 @@ partial class Grammar
         {
             var accumulator = new List<TValue>();
 
-            var oldIndex = index;
-            string? itemExpectation;
+        var oldIndex = index;
+        string? itemExpectation;
 
-            while (item(input, ref index, out var itemValue, out itemExpectation))
-            {
-                if (oldIndex == index)
-                    throw new Exception($"Parser encountered a potential infinite loop at index {index}.");
+        while (item(input, ref index, out var itemValue, out itemExpectation))
+        {
+            if (oldIndex == index)
+                throw new Exception($"Parser encountered a potential infinite loop at index {index}.");
 
-                accumulator.Add(itemValue);
+            accumulator.Add(itemValue);
 
-                oldIndex = index;
-            }
+            oldIndex = index;
+        }
 
-            //The item parser finally failed.
+        //The item parser finally failed.
 
-            if (oldIndex != index)
-            {
-                expectation = itemExpectation;
-                values = null;
-                return false;
-            }
+        if (oldIndex != index)
+        {
+            expectation = itemExpectation;
+            values = null;
+            return false;
+        }
 
-            expectation = null;
-            values = accumulator;
-            return true;
+        expectation = null;
+        values = accumulator;
+        return true;
         };
     }
 

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -46,9 +46,9 @@ partial class Grammar
     /// end of the sequence, p must fail without consuming input, otherwise the
     /// sequence will fail with the error reported by p.
     /// </summary>
-    public static Parser<TItem, IEnumerable<TValue>> ZeroOrMore<TItem, TValue>(Parser<TItem, TValue> item)
+    public static Parser<TItem, IReadOnlyList<TValue>> ZeroOrMore<TItem, TValue>(Parser<TItem, TValue> item)
     {
-        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out IEnumerable<TValue>? values, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out IReadOnlyList<TValue>? values, [NotNullWhen(false)] out string? expectation) =>
         {
             var accumulator = new List<TValue>();
 
@@ -59,9 +59,9 @@ partial class Grammar
     /// <summary>
     /// OneOrMore(p) behaves like ZeroOrMore(p), except that p must succeed at least one time.
     /// </summary>
-    public static Parser<TItem, IEnumerable<TValue>> OneOrMore<TItem, TValue>(Parser<TItem, TValue> item)
+    public static Parser<TItem, IReadOnlyList<TValue>> OneOrMore<TItem, TValue>(Parser<TItem, TValue> item)
     {
-        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out IEnumerable<TValue>? values, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out IReadOnlyList<TValue>? values, [NotNullWhen(false)] out string? expectation) =>
         {
             var accumulator = new List<TValue>();
 
@@ -85,9 +85,9 @@ partial class Grammar
     /// ZeroOrMore(p, s) parses zero or more occurrences of p separated by occurrences of s,
     /// returning the list of values returned by successful applications of p.
     /// </summary>
-    public static Parser<TItem, IEnumerable<TValue>> ZeroOrMore<TItem, TValue, S>(Parser<TItem, TValue> item, Parser<TItem, S> separator)
+    public static Parser<TItem, IReadOnlyList<TValue>> ZeroOrMore<TItem, TValue, S>(Parser<TItem, TValue> item, Parser<TItem, S> separator)
     {
-        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out IEnumerable<TValue>? values, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out IReadOnlyList<TValue>? values, [NotNullWhen(false)] out string? expectation) =>
         {
             var accumulator = new List<TValue>();
             var originalIndex = index;
@@ -125,9 +125,9 @@ partial class Grammar
     /// <summary>
     /// OneOrMore(p, s) behaves like ZeroOrMore(p, s), except that p must succeed at least one time.
     /// </summary>
-    public static Parser<TItem, IEnumerable<TValue>> OneOrMore<TItem, TValue, S>(Parser<TItem, TValue> item, Parser<TItem, S> separator)
+    public static Parser<TItem, IReadOnlyList<TValue>> OneOrMore<TItem, TValue, S>(Parser<TItem, TValue> item, Parser<TItem, S> separator)
     {
-        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out IEnumerable<TValue>? values, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out IReadOnlyList<TValue>? values, [NotNullWhen(false)] out string? expectation) =>
         {
             var accumulator = new List<TValue>();
 
@@ -156,7 +156,7 @@ partial class Grammar
                                       Parser<TItem, TValue> item,
                                       ReadOnlySpan<TItem> input,
                                       ref int index,
-                                      [NotNullWhen(true)] out IEnumerable<TValue>? values,
+                                      [NotNullWhen(true)] out IReadOnlyList<TValue>? values,
                                       [NotNullWhen(false)] out string? expectation)
     {
         var oldIndex = index;

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -52,6 +52,17 @@ partial class Grammar
         {
             var accumulator = new List<TValue>();
 
+            return Repeat(accumulator, item, input, ref index, out values, out expectation);
+        };
+    }
+
+    static bool Repeat<TItem, TValue>(List<TValue> accumulator,
+                                      Parser<TItem, TValue> item,
+                                      ReadOnlySpan<TItem> input,
+                                      ref int index,
+                                      [NotNullWhen(true)] out IEnumerable<TValue>? values,
+                                      [NotNullWhen(false)] out string? expectation)
+    {
         var oldIndex = index;
         string? itemExpectation;
 
@@ -77,7 +88,6 @@ partial class Grammar
         expectation = null;
         values = accumulator;
         return true;
-        };
     }
 
     /// <summary>

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -50,9 +50,10 @@ partial class Grammar
     {
         return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out IEnumerable<TValue>? values, [NotNullWhen(false)] out string? expectation) =>
         {
+            var accumulator = new List<TValue>();
+
             var oldIndex = index;
             string? itemExpectation;
-            var accumulator = new List<TValue>();
 
             while (item(input, ref index, out var itemValue, out itemExpectation))
             {


### PR DESCRIPTION
This rephrases the implementation of repetition parsers ZeroOrMore(p), OneOrMore(p), ZeroOrMore(p, separator), OneOrMore(p, separator), favoring efficiency and end user experience over brevity of the implementation.

Previously, `ZeroOrMore(p)` was the only one of the 4 implemented as an explicit loop while the other three were implemented as short combinations of `ZeroOrMore(p)` with other primitives like `Choice(...)`. Although it worked, the approach had unintended effects. The `OneOrMore` overloads would produce an `IEnumerable`, and one that lacked locality-of-reference between the first and remaining items, and the use of a lazy `IEnumerable` forced end users to realize the collection in practice, so wasn't saving on memory in practice anyway. Further, although no bug was encountered, it's unclear whether the lazy evaluation of the generator in combination with the way progress tracking takes place could result in unsound behavior.

Now, the *primary loop within* `ZeroOrMore(p)` is extracted to a private helper method, `Repeat`, and the 4 public repetition methods are defined more explicitly while still deferring to the common loop when possible. We fully take advantage of `List<T>`'s own memory locality and capacity-vs-size tradeoffs, for minimal allocations in practice. End users get to interact with the compact result using the `IReadOnlyList<T>` interface instead of `IEnumerable<T>`.