### PR TITLE
Parser Covariance

### DIFF
--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -1,15 +1,14 @@
-using System.Diagnostics.CodeAnalysis;
 using static Parsley.Grammar;
 
 namespace Parsley.Tests;
 
 class GrammarTests
 {
-    static readonly Parser<char, string> Fail = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
+    static readonly Parser<char, string> Fail = (ReadOnlySpan<char> input, ref int index, out bool succeeded, out string? expectation) =>
     {
         expectation = "unsatisfiable expectation";
-        value = null;
-        return false;
+        succeeded = false;
+        return null;
     };
     static readonly Parser<char, char> Digit = Single<char>(char.IsDigit, "Digit");
     static readonly Parser<char, char> Letter = Single<char>(char.IsLetter, "Letter");
@@ -571,11 +570,11 @@ public class AlternationTests
         //consuming input. These tests simply describe the behavior under that
         //unusual situation.
 
-        Parser<char, string> succeedWithoutConsuming = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
+        Parser<char, string> succeedWithoutConsuming = (ReadOnlySpan<char> input, ref int index, out bool succeeded, out string? expectation) =>
         {
             expectation = null;
-            value = "atypical value";
-            return true;
+            succeeded = true;
+            return "atypical value";
         };
 
         Choice(A, succeedWithoutConsuming).Parses("").ShouldBe("atypical value");
@@ -584,6 +583,6 @@ public class AlternationTests
     }
 
     static readonly Parser<char, string> NeverExecuted =
-        (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation)
+        (ReadOnlySpan<char> input, ref int index, out bool succeeded, out string? expectation)
             => throw new Exception("Parser 'NeverExecuted' should not have been executed.");
 }

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using static Parsley.Grammar;
 
@@ -97,13 +96,13 @@ public class JsonGrammar
 
     static Parser<char, decimal> Evaluate(string candidate)
     {
-        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out decimal value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<char> input, ref int index, out bool succeeded, out string? expectation) =>
         {
-            var valid = decimal.TryParse(candidate, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
+            succeeded = decimal.TryParse(candidate, NumberStyles.Any, CultureInfo.InvariantCulture, out decimal value);
 
-            expectation = valid ? null : "decimal within valid range";
+            expectation = succeeded ? null : "decimal within valid range";
 
-            return valid;
+            return value;
         };
     }
 

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
@@ -8,7 +8,7 @@ public class JsonGrammar
     public static readonly Parser<char, object?> JsonDocument;
 
     static readonly Parser<char, string> Whitespace = ZeroOrMore(char.IsWhiteSpace);
-    static readonly Parser<char, object?> Value = default!;
+    static readonly Parser<char, object?> Value;
 
     static JsonGrammar()
     {
@@ -18,15 +18,7 @@ public class JsonGrammar
 
         Value =
             from leading in Whitespace
-            from value in Choice(
-                True,
-                False,
-                Null,
-                Number,
-                from quotation in Quote select (object) quotation,
-                Dictionary,
-                Array
-            )
+            from value in Choice(True, False, Null, Number, Quote, Dictionary, Array)
             from trailing in Whitespace
             select value;
 
@@ -44,7 +36,7 @@ public class JsonGrammar
         from open in Operator("[")
         from items in ZeroOrMore(Value, Operator(","))
         from close in Operator("]")
-        select (object) items.ToArray();
+        select items.ToArray();
 
     static Parser<char, object> Dictionary
     {
@@ -66,7 +58,7 @@ public class JsonGrammar
                 from open in Operator("{")
                 from pairs in ZeroOrMore(Pair, Operator(","))
                 from close in Operator("}")
-                select (object) pairs.ToDictionary(x => x.Key, x => x.Value);
+                select pairs.ToDictionary(x => x.Key, x => x.Value);
         }
     }
 

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammarTests.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammarTests.cs
@@ -1,5 +1,3 @@
-using System.Globalization;
-
 namespace Parsley.Tests.IntegrationTests.Json;
 
 using static JsonGrammar;

--- a/src/Parsley.Tests/OperatorPrecedenceParserTests.cs
+++ b/src/Parsley.Tests/OperatorPrecedenceParserTests.cs
@@ -33,7 +33,7 @@ class OperatorPrecedenceParserTests
             from open in LeftParen
             from arguments in ZeroOrMore(expression.Parser, Comma)
             from close in RightParen
-            select (IExpression) new Form(callable, arguments));
+            select new Form(callable, arguments));
     }
 
     public void ParsesRegisteredTokensIntoCorrespondingAtoms()

--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using static Parsley.Grammar;
 
@@ -8,11 +7,11 @@ class ParserQueryTests
 {
     static readonly Parser<char, char> Next = Single<char>(_ => true, "character");
 
-    static readonly Parser<char, string> Fail = (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
+    static readonly Parser<char, string> Fail = (ReadOnlySpan<char> input, ref int index, out bool succeeded, out string? expectation) =>
     {
         expectation = "unsatisfiable expectation";
-        value = null;
-        return false;
+        succeeded = false;
+        return null;
     };
 
     public void CanBuildParserWhichSimulatesSuccessfulParsingOfGivenValueWithoutConsumingInput()

--- a/src/Parsley/Assertions.cs
+++ b/src/Parsley/Assertions.cs
@@ -10,7 +10,9 @@ public static class Assertions
         ReadOnlySpan<char> inputSpan = input;
         int index = 0;
 
-        if (parse(inputSpan, ref index, out var value, out var expectation))
+        var value = parse(inputSpan, ref index, out var succeeded, out var expectation);
+
+        if (succeeded)
             throw new AssertionException("parser failure", "parser completed successfully");
 
         var actual = expectation + " expected";
@@ -29,15 +31,17 @@ public static class Assertions
         ReadOnlySpan<char> inputSpan = input;
         int index = 0;
 
-        if (!parse(inputSpan, ref index, out var value, out var expectation))
-            UnexpectedFailure(inputSpan, ref index, expectation);
+        var value = parse(inputSpan, ref index, out var succeeded, out var expectation);
+
+        if (!succeeded)
+            UnexpectedFailure(inputSpan, ref index, expectation!);
 
         if (expectedUnparsedInput == "")
             throw new ArgumentException($"{nameof(expectedUnparsedInput)} must be nonempty when calling {nameof(PartiallyParses)}.");
 
         inputSpan.LeavingUnparsedInput(index, expectedUnparsedInput);
 
-        return value;
+        return value!;
     }
 
     public static TValue Parses<TValue>(this Parser<char, TValue> parse, string input)
@@ -45,12 +49,14 @@ public static class Assertions
         ReadOnlySpan<char> inputSpan = input;
         int index = 0;
 
-        if (!parse(inputSpan, ref index, out var value, out var expectation))
-            UnexpectedFailure(inputSpan, ref index, expectation);
+        var value = parse(inputSpan, ref index, out var succeeded, out var expectation);
+
+        if (!succeeded)
+            UnexpectedFailure(inputSpan, ref index, expectation!);
 
         inputSpan.AtEndOfInput(index);
 
-        return value;
+        return value!;
     }
 
     [DoesNotReturn]

--- a/src/Parsley/Grammar.Attempt.cs
+++ b/src/Parsley/Grammar.Attempt.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Parsley;
 
 partial class Grammar
@@ -11,16 +9,16 @@ partial class Grammar
     /// </summary>
     public static Parser<TItem, TValue> Attempt<TItem, TValue>(Parser<TItem, TValue> parse)
     {
-        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out TValue? value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
         {
             var originalIndex = index;
 
-            if (parse(input, ref index, out value, out expectation))
-                return true;
+            var value = parse(input, ref index, out succeeded, out expectation);
 
-            index = originalIndex;
+            if (!succeeded)
+                index = originalIndex;
 
-            return false;
+            return value;
         };
     }
 }

--- a/src/Parsley/Grammar.EndOfInput.cs
+++ b/src/Parsley/Grammar.EndOfInput.cs
@@ -1,25 +1,21 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Parsley;
 
 partial class Grammar
 {
     public static Parser<TItem, Void> EndOfInput<TItem>()
     {
-        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out Void value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
         {
-            value = Void.Value;
-
             if (index == input.Length)
             {
                 expectation = null;
-
-                return true;
+                succeeded = true;
+                return Void.Value;
             }
 
             expectation = "end of input";
-
-            return false;
+            succeeded = false;
+            return Void.Value;
         };
     }
 }

--- a/src/Parsley/Grammar.Keyword.cs
+++ b/src/Parsley/Grammar.Keyword.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Parsley;
 
 partial class Grammar
@@ -9,7 +7,7 @@ partial class Grammar
         if (word.Any(ch => !char.IsLetter(ch)))
             throw new ArgumentException("Keywords may only contain letters.", nameof(word));
 
-        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<char> input, ref int index, out bool succeeded, out string? expectation) =>
         {
             var peek = input.Peek(index, word.Length + 1);
 
@@ -19,15 +17,15 @@ partial class Grammar
                 {
                     index += word.Length;
 
+                    succeeded = true;
                     expectation = null;
-                    value = word;
-                    return true;
+                    return word;
                 }
             }
 
+            succeeded = false;
             expectation = word;
-            value = null;
-            return false;
+            return null;
         };
     }
 }

--- a/src/Parsley/Grammar.Label.cs
+++ b/src/Parsley/Grammar.Label.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Parsley;
 
 partial class Grammar
@@ -11,17 +9,17 @@ partial class Grammar
     /// </summary>
     public static Parser<TItem, TValue> Label<TItem, TValue>(Parser<TItem, TValue> parse, string label)
     {
-        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out TValue? value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
         {
             var originalIndex = index;
 
-            if (parse(input, ref index, out value, out expectation))
-                return true;
+            var value = parse(input, ref index, out succeeded, out expectation);
 
-            if (originalIndex == index)
-                expectation = label;
+            if (!succeeded)
+                if (originalIndex == index)
+                    expectation = label;
 
-            return false;
+            return value;
         };
     }
 }

--- a/src/Parsley/Grammar.Not.cs
+++ b/src/Parsley/Grammar.Not.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Parsley;
 
 partial class Grammar
@@ -10,20 +8,24 @@ partial class Grammar
     /// </summary>
     public static Parser<TItem, Void> Not<TItem, TValue>(Parser<TItem, TValue> parse)
     {
-        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out Void value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
         {
-            value = Void.Value;
-
             var copyOfIndex = index;
 
-            if (parse(input, ref copyOfIndex, out _, out _))
+            var ignoredValue = parse(input, ref copyOfIndex, out var parseSucceeded, out _);
+
+            if (parseSucceeded)
             {
                 expectation = "parse failure";
-                return false;
+                succeeded = false;
+            }
+            else
+            {
+                expectation = null;
+                succeeded = true;
             }
 
-            expectation = null;
-            return true;
+            return Void.Value;
         };
     }
 }

--- a/src/Parsley/Grammar.Operator.cs
+++ b/src/Parsley/Grammar.Operator.cs
@@ -1,12 +1,10 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Parsley;
 
 partial class Grammar
 {
     public static Parser<char, string> Operator(string symbol)
     {
-        return (ReadOnlySpan<char> input, ref int index, [NotNullWhen(true)] out string? value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<char> input, ref int index, out bool succeeded, out string? expectation) =>
         {
             var peek = input.Peek(index, symbol.Length);
 
@@ -14,14 +12,14 @@ partial class Grammar
             {
                 index += symbol.Length;
 
+                succeeded = true;
                 expectation = null;
-                value = symbol;
-                return true;
+                return symbol;
             }
 
+            succeeded = false;
             expectation = symbol;
-            value = null;
-            return false;
+            return null;
         };
     }
 }

--- a/src/Parsley/Grammar.Optional.cs
+++ b/src/Parsley/Grammar.Optional.cs
@@ -12,9 +12,7 @@ public static partial class Grammar
         where TValue : class
     {
         var nothing = default(TValue).SucceedWithThisValue<TItem, TValue?>();
-        return Choice(
-            from x in parser
-            select (TValue?)x, nothing);
+        return Choice(parser, nothing);
     }
 
     /// <summary>

--- a/src/Parsley/Grammar.Single.cs
+++ b/src/Parsley/Grammar.Single.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Parsley;
 
 partial class Grammar
@@ -11,7 +9,7 @@ partial class Grammar
 
     public static Parser<TItem, TItem> Single<TItem>(Func<TItem, bool> test, string name)
     {
-        return (ReadOnlySpan<TItem> input, ref int index, [NotNullWhen(true)] out TItem? value, [NotNullWhen(false)] out string? expectation) =>
+        return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
         {
             if (index + 1 <= input.Length)
             {
@@ -21,14 +19,14 @@ partial class Grammar
                     index += 1;
 
                     expectation = null;
-                    value = c;
-                    return true;
+                    succeeded = true;
+                    return c;
                 }
             }
 
             expectation = name;
-            value = default;
-            return false;
+            succeeded = false;
+            return default;
         };
     }
 }

--- a/src/Parsley/Parser.cs
+++ b/src/Parsley/Parser.cs
@@ -1,9 +1,7 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Parsley;
 
-public delegate bool Parser<TItem, TValue>(
+public delegate TValue? Parser<TItem, TValue>(
     ReadOnlySpan<TItem> input,
     ref int index,
-    [NotNullWhen(true)] out TValue? value,
-    [NotNullWhen(false)] out string? expectation);
+    out bool succeeded,
+    out string? expectation);

--- a/src/Parsley/Parser.cs
+++ b/src/Parsley/Parser.cs
@@ -1,6 +1,6 @@
 namespace Parsley;
 
-public delegate TValue? Parser<TItem, TValue>(
+public delegate TValue? Parser<TItem, out TValue>(
     ReadOnlySpan<TItem> input,
     ref int index,
     out bool succeeded,


### PR DESCRIPTION
This reintroduces the desirable Parser covariance that we briefly lost back in #22. In short, end users will need to perform explicit casts in their parsers less often.

This involved rearranging the Parser type so that the outgoing value appeared only in the Parser delegate's return type (`out` parameters don't count as returns, when considering covariance, so we weren't allowed to use covariance until now).

Before:

```cs
public delegate bool Parser<TItem, TValue>(
    ReadOnlySpan<TItem> input,
    ref int index,
    [NotNullWhen(true)] out TValue? value,
    [NotNullWhen(false)] out string? expectation);
```

After:

```cs
public delegate TValue? Parser<TItem, out TValue>(
    ReadOnlySpan<TItem> input,
    ref int index,
    out bool succeeded,
    out string? expectation);
```

Note that once `TValue` appears *only* in the return type, we are allowed to mark `TValue` as having `out` covariance, which translates into end user simplifications as seen in the changes to the JSON example.

Unfortunately, the `NotNullWhen` attribute is no longer applicable, and so no longer aids the compiler in deciding that our many low-level parsers are valid, so the trade-off here was end user experience over the frustration of marking `value` and `expectation` with the `!` null forgiveness operator based on whether or not the `succeeded` value was true. Overall, there is no substantive change in behavior regarding nulls, but we do have to be more explicit on occasion.