### PR TITLE
Multi-phase parsers

### DIFF
--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -459,6 +459,13 @@ class GrammarTests
         upper.Parses("DEF").ShouldBe("DEF");
 
         caseInsensitive.Parses("abcDEF").ShouldBe("abcDEF");
+
+        var even = ZeroOrMore<int>(x => x % 2 == 0);
+        var empty = Array.Empty<int>();
+        even.Parses(empty).ShouldBe(empty);
+        even.PartiallyParses(new[] { 1, 2, 4, 6 }, new[] { 1, 2, 4, 6 }).ShouldBe(empty);
+        even.PartiallyParses(new[] { 2, 4, 6, 1, 3, 5 }, new[] { 1, 3, 5 }).ShouldBe(new[] { 2, 4, 6 });
+        even.Parses(new[] { 2, 4, 6 }).ShouldBe(new[] { 2, 4, 6 });
     }
 
     public void ProvidesConveniencePrimitiveRecognizingNonemptySequencesOfItemsSatisfyingSomePredicate()
@@ -480,6 +487,13 @@ class GrammarTests
         upper.Parses("DEF").ShouldBe("DEF");
 
         caseInsensitive.Parses("abcDEF").ShouldBe("abcDEF");
+
+        var even = OneOrMore<int>(x => x % 2 == 0, "even number");
+        var empty = Array.Empty<int>();
+        even.FailsToParse(empty, empty, "even number expected");
+        even.FailsToParse(new[] { 1, 2, 4, 6 }, new[] { 1, 2, 4, 6 }, "even number expected");
+        even.PartiallyParses(new[] { 2, 4, 6, 1, 3, 5 }, new[] { 1, 3, 5 }).ShouldBe(new[] { 2, 4, 6 });
+        even.Parses(new[] { 2, 4, 6 }).ShouldBe(new[] { 2, 4, 6 });
     }
 
     public void ProvidesConveniencePrimitiveForDefiningKeywords()

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
@@ -19,9 +19,9 @@ public class JsonGrammar
         var False = Token("false");
         var Null = Token("null");
         var Number = Token("number");
-        var Quote = Token("quote");
+        var String = Token("string");
 
-        Value = Recursive(() => Choice(True, False, Null, Number, Quote, Dictionary, Array));
+        Value = Recursive(() => Choice(True, False, Null, Number, String, Dictionary, Array));
 
         JsonDocument = (ReadOnlySpan<char> input, ref int index, out bool succeeded, out string? expectation) =>
         {
@@ -77,7 +77,7 @@ public class JsonGrammar
         List(Pair, "{", "}").Select(pairs => pairs.ToDictionary(x => (string)x.key, x => x.value));
 
     static Parser<JsonToken, (object key, object? value)> Pair =>
-        from key in Token("quote")
+        from key in Token("string")
         from colon in Token(":")
         from value in Value
         select (key, value);
@@ -159,7 +159,7 @@ public class JsonGrammar
                         Single<char>(c => c != '"' && c != '\\', "non-quote, not-slash character").Select(x => x.ToString())
                     ))
                 from close in Single('"')
-                select new JsonToken("quote", string.Join("", content));
+                select new JsonToken("string", string.Join("", content));
         }
     }
 }

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
@@ -6,10 +6,9 @@ namespace Parsley.Tests.IntegrationTests.Json;
 
 public class JsonGrammar
 {
-    public static readonly Parser<char, object?> JsonDocument;
+    public static readonly Parser<char, object?> Json;
 
     static readonly Parser<char, Void> Whitespace = Skip(IsWhiteSpace);
-    static readonly Parser<char, object?> Value;
 
     static JsonGrammar()
     {
@@ -17,15 +16,10 @@ public class JsonGrammar
         var False = Literal("false", false);
         var Null = Literal("null", null);
 
-        Value =
+        Json =
             from leading in Whitespace
             from value in Choice(True, False, Null, Number, Quote, Dictionary, Array)
             from trailing in Whitespace
-            select value;
-
-        JsonDocument =
-            from value in Value
-            from end in EndOfInput<char>()
             select value;
     }
 
@@ -35,7 +29,7 @@ public class JsonGrammar
 
     static Parser<char, object> Array =>
         from open in Operator("[")
-        from items in ZeroOrMore(Value, Operator(","))
+        from items in ZeroOrMore(Json, Operator(","))
         from close in Operator("]")
         select items.ToArray();
 
@@ -52,7 +46,7 @@ public class JsonGrammar
             var Pair =
                 from key in Key
                 from colon in Operator(":")
-                from value in Value
+                from value in Json
                 select new KeyValuePair<string, object>(key, value);
 
             return

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammar.cs
@@ -6,7 +6,7 @@ namespace Parsley.Tests.IntegrationTests.Json;
 
 public class JsonGrammar
 {
-    public static readonly Parser<char, object?> Json;
+    public static readonly Parser<char, object?> JsonDocument;
 
     static readonly Parser<char, Void> Whitespace = Skip(IsWhiteSpace);
 
@@ -16,7 +16,7 @@ public class JsonGrammar
         var False = Literal("false", false);
         var Null = Literal("null", null);
 
-        Json =
+        JsonDocument =
             from leading in Whitespace
             from value in Choice(True, False, Null, Number, Quote, Dictionary, Array)
             from trailing in Whitespace
@@ -29,7 +29,7 @@ public class JsonGrammar
 
     static Parser<char, object> Array =>
         from open in Operator("[")
-        from items in ZeroOrMore(Json, Operator(","))
+        from items in ZeroOrMore(JsonDocument, Operator(","))
         from close in Operator("]")
         select items.ToArray();
 
@@ -46,7 +46,7 @@ public class JsonGrammar
             var Pair =
                 from key in Key
                 from colon in Operator(":")
-                from value in Json
+                from value in JsonDocument
                 select new KeyValuePair<string, object>(key, value);
 
             return

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammarTests.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammarTests.cs
@@ -6,34 +6,34 @@ class JsonGrammarTests
 {
     public void ParsesTrueLiteral()
     {
-        Json.Parses("true").ShouldBe(true);
+        JsonDocument.Parses("true").ShouldBe(true);
     }
 
     public void ParsesFalseLiteral()
     {
-        Json.Parses("false").ShouldBe(false);
+        JsonDocument.Parses("false").ShouldBe(false);
     }
 
     public void ParsesNullLiteral()
     {
-        Json.Parses("null").ShouldBe(null);
+        JsonDocument.Parses("null").ShouldBe(null);
     }
 
     public void ParsesNumbers()
     {
-        Json.Parses("0").ShouldBe(0m);
-        Json.Parses("12345").ShouldBe(12345m);
-        Json.Parses("0.012").ShouldBe(0.012m);
-        Json.Parses("0e1").ShouldBe(0e1m);
-        Json.Parses("0e+1").ShouldBe(0e+1m);
-        Json.Parses("0e-1").ShouldBe(0e-1m);
-        Json.Parses("0E1").ShouldBe(0E1m);
-        Json.Parses("0E+1").ShouldBe(0E+1m);
-        Json.Parses("0E-1").ShouldBe(0E-1m);
-        Json.Parses("10e11").ShouldBe(10e11m);
-        Json.Parses("10.123e11").ShouldBe(10.123e11m);
-        Json.Parses("10.123E-11").ShouldBe(10.123E-11m);
-        Json.FailsToParse("9" + decimal.MaxValue, "", "decimal within valid range expected");
+        JsonDocument.Parses("0").ShouldBe(0m);
+        JsonDocument.Parses("12345").ShouldBe(12345m);
+        JsonDocument.Parses("0.012").ShouldBe(0.012m);
+        JsonDocument.Parses("0e1").ShouldBe(0e1m);
+        JsonDocument.Parses("0e+1").ShouldBe(0e+1m);
+        JsonDocument.Parses("0e-1").ShouldBe(0e-1m);
+        JsonDocument.Parses("0E1").ShouldBe(0E1m);
+        JsonDocument.Parses("0E+1").ShouldBe(0E+1m);
+        JsonDocument.Parses("0E-1").ShouldBe(0E-1m);
+        JsonDocument.Parses("10e11").ShouldBe(10e11m);
+        JsonDocument.Parses("10.123e11").ShouldBe(10.123e11m);
+        JsonDocument.Parses("10.123E-11").ShouldBe(10.123E-11m);
+        JsonDocument.FailsToParse("9" + decimal.MaxValue, "", "decimal within valid range expected");
     }
 
     public void ParsesQuotations()
@@ -42,8 +42,8 @@ class JsonGrammarTests
         var filled = "\"abc \\\" \\\\ \\/ \\b \\f \\n \\r \\t \\u263a def\"";
         const string expected = "abc \" \\ / \b \f \n \r \t ☺ def";
 
-        Json.Parses(empty).ShouldBe("");
-        Json.Parses(filled).ShouldBe(expected);
+        JsonDocument.Parses(empty).ShouldBe("");
+        JsonDocument.Parses(filled).ShouldBe(expected);
     }
 
     public void ParsesArrays()
@@ -51,11 +51,11 @@ class JsonGrammarTests
         var empty = "[]";
         var filled = "[0, 1, 2]";
 
-        var emptyValue = Json.Parses(empty);
+        var emptyValue = JsonDocument.Parses(empty);
         emptyValue.ShouldNotBeNull();
         ((object[]) emptyValue).ShouldBeEmpty();
 
-        var value = Json.Parses(filled);
+        var value = JsonDocument.Parses(filled);
         value.ShouldNotBeNull();
         ((object[]) value).ShouldBe(new object[] { 0m, 1m, 2m });
     }
@@ -65,11 +65,11 @@ class JsonGrammarTests
         var empty = "{}";
         var filled = "{\"zero\" : 0, \"one\" : 1, \"two\" : 2}";
 
-        var emptyValue = Json.Parses(empty);
+        var emptyValue = JsonDocument.Parses(empty);
         emptyValue.ShouldNotBeNull();
         ((Dictionary<string, object>) emptyValue).Count.ShouldBe(0);
 
-        var value = Json.Parses(filled);
+        var value = JsonDocument.Parses(filled);
         value.ShouldNotBeNull();
 
         var dictionary = (Dictionary<string, object>) value;
@@ -97,7 +97,7 @@ class JsonGrammarTests
 
             " + whitespaceCharacters;
 
-        var value = Json.Parses(complex);
+        var value = JsonDocument.Parses(complex);
         value.ShouldNotBeNull();
 
         var json = (Dictionary<string, object>) value;
@@ -126,7 +126,7 @@ class JsonGrammarTests
                     }
                 }";
 
-        Json.FailsToParse(invalidSlashP,
+        JsonDocument.FailsToParse(invalidSlashP,
             @"parent"": false
                     }
                 }",

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonGrammarTests.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonGrammarTests.cs
@@ -6,34 +6,34 @@ class JsonGrammarTests
 {
     public void ParsesTrueLiteral()
     {
-        JsonDocument.Parses("true").ShouldBe(true);
+        Json.Parses("true").ShouldBe(true);
     }
 
     public void ParsesFalseLiteral()
     {
-        JsonDocument.Parses("false").ShouldBe(false);
+        Json.Parses("false").ShouldBe(false);
     }
 
     public void ParsesNullLiteral()
     {
-        JsonDocument.Parses("null").ShouldBe(null);
+        Json.Parses("null").ShouldBe(null);
     }
 
     public void ParsesNumbers()
     {
-        JsonDocument.Parses("0").ShouldBe(0m);
-        JsonDocument.Parses("12345").ShouldBe(12345m);
-        JsonDocument.Parses("0.012").ShouldBe(0.012m);
-        JsonDocument.Parses("0e1").ShouldBe(0e1m);
-        JsonDocument.Parses("0e+1").ShouldBe(0e+1m);
-        JsonDocument.Parses("0e-1").ShouldBe(0e-1m);
-        JsonDocument.Parses("0E1").ShouldBe(0E1m);
-        JsonDocument.Parses("0E+1").ShouldBe(0E+1m);
-        JsonDocument.Parses("0E-1").ShouldBe(0E-1m);
-        JsonDocument.Parses("10e11").ShouldBe(10e11m);
-        JsonDocument.Parses("10.123e11").ShouldBe(10.123e11m);
-        JsonDocument.Parses("10.123E-11").ShouldBe(10.123E-11m);
-        JsonDocument.FailsToParse("9" + decimal.MaxValue, "", "decimal within valid range expected");
+        Json.Parses("0").ShouldBe(0m);
+        Json.Parses("12345").ShouldBe(12345m);
+        Json.Parses("0.012").ShouldBe(0.012m);
+        Json.Parses("0e1").ShouldBe(0e1m);
+        Json.Parses("0e+1").ShouldBe(0e+1m);
+        Json.Parses("0e-1").ShouldBe(0e-1m);
+        Json.Parses("0E1").ShouldBe(0E1m);
+        Json.Parses("0E+1").ShouldBe(0E+1m);
+        Json.Parses("0E-1").ShouldBe(0E-1m);
+        Json.Parses("10e11").ShouldBe(10e11m);
+        Json.Parses("10.123e11").ShouldBe(10.123e11m);
+        Json.Parses("10.123E-11").ShouldBe(10.123E-11m);
+        Json.FailsToParse("9" + decimal.MaxValue, "", "decimal within valid range expected");
     }
 
     public void ParsesQuotations()
@@ -42,8 +42,8 @@ class JsonGrammarTests
         var filled = "\"abc \\\" \\\\ \\/ \\b \\f \\n \\r \\t \\u263a def\"";
         const string expected = "abc \" \\ / \b \f \n \r \t ☺ def";
 
-        JsonDocument.Parses(empty).ShouldBe("");
-        JsonDocument.Parses(filled).ShouldBe(expected);
+        Json.Parses(empty).ShouldBe("");
+        Json.Parses(filled).ShouldBe(expected);
     }
 
     public void ParsesArrays()
@@ -51,11 +51,11 @@ class JsonGrammarTests
         var empty = "[]";
         var filled = "[0, 1, 2]";
 
-        var emptyValue = JsonDocument.Parses(empty);
+        var emptyValue = Json.Parses(empty);
         emptyValue.ShouldNotBeNull();
         ((object[]) emptyValue).ShouldBeEmpty();
 
-        var value = JsonDocument.Parses(filled);
+        var value = Json.Parses(filled);
         value.ShouldNotBeNull();
         ((object[]) value).ShouldBe(new object[] { 0m, 1m, 2m });
     }
@@ -65,11 +65,11 @@ class JsonGrammarTests
         var empty = "{}";
         var filled = "{\"zero\" : 0, \"one\" : 1, \"two\" : 2}";
 
-        var emptyValue = JsonDocument.Parses(empty);
+        var emptyValue = Json.Parses(empty);
         emptyValue.ShouldNotBeNull();
         ((Dictionary<string, object>) emptyValue).Count.ShouldBe(0);
 
-        var value = JsonDocument.Parses(filled);
+        var value = Json.Parses(filled);
         value.ShouldNotBeNull();
 
         var dictionary = (Dictionary<string, object>) value;
@@ -97,7 +97,7 @@ class JsonGrammarTests
 
             " + whitespaceCharacters;
 
-        var value = JsonDocument.Parses(complex);
+        var value = Json.Parses(complex);
         value.ShouldNotBeNull();
 
         var json = (Dictionary<string, object>) value;
@@ -126,19 +126,10 @@ class JsonGrammarTests
                     }
                 }";
 
-        JsonDocument.FailsToParse(invalidSlashP,
+        Json.FailsToParse(invalidSlashP,
             @"parent"": false
                     }
                 }",
             "(escape character or unicode escape sequence) expected");
-    }
-
-    public void RequiresEndOfInputAfterFirstValidJsonValue()
-    {
-        JsonDocument.FailsToParse("true $garbage$", "$garbage$", "end of input expected");
-        JsonDocument.FailsToParse("10.123E-11  $garbage$", "$garbage$", "end of input expected");
-        JsonDocument.FailsToParse("\"garbage\" $garbage$", "$garbage$", "end of input expected");
-        JsonDocument.FailsToParse("[0, 1, 2] $garbage$", "$garbage$", "end of input expected");
-        JsonDocument.FailsToParse("{\"zero\" : 0} $garbage$", "$garbage$", "end of input expected");
     }
 }

--- a/src/Parsley/Assertions.cs
+++ b/src/Parsley/Assertions.cs
@@ -45,22 +45,21 @@ public static class Assertions
     [DoesNotReturn]
     static void UnexpectedFailure<TItem>(ReadOnlySpan<TItem> input, ParseError error)
     {
-        var message = new StringBuilder();
-        var peek = input.Peek(error.Index, 20).ToString();
+        var message = new StringBuilder()
+            .AppendLine(error.Index + ": " + error.Expectation + " expected");
+
+        var peek = input.Peek(error.Index, 20);
 
         if (peek.Length > 0)
         {
-            var offendingItem = peek[0];
-            var displayFriendlyTrailingItems = new string(peek.Skip(1).TakeWhile(x => !char.IsControl(x)).ToArray());
-
-            message.AppendLine(error.Index + ": " + error.Expectation + " expected");
             message.AppendLine();
-            message.AppendLine($"\t{offendingItem}{displayFriendlyTrailingItems}");
+
+            var displayPeek = typeof(TItem) == typeof(char)
+                ? new string(peek.ToString().TakeWhile(x => !char.IsControl(x)).ToArray())
+                : Display(peek);
+
+            message.AppendLine($"\t{displayPeek}");
             message.AppendLine("\t^");
-        }
-        else
-        {
-            message.AppendLine(error.Index + ": " + error.Expectation + " expected");
         }
 
         throw new AssertionException(message.ToString(), "parser success", "parser failure");
@@ -91,5 +90,5 @@ public static class Assertions
     static string Display<TItem>(ReadOnlySpan<TItem> unparsedInput)
         => typeof(TItem) == typeof(char)
             ? unparsedInput.ToString()
-            : $"[{string.Join(", ", unparsedInput.ToArray().Select(x => x?.ToString()))}]";
+            : string.Join(", ", unparsedInput.ToArray().Select(x => x?.ToString()));
 }

--- a/src/Parsley/Grammar.Recursive.cs
+++ b/src/Parsley/Grammar.Recursive.cs
@@ -1,0 +1,15 @@
+namespace Parsley;
+
+partial class Grammar
+{
+    /// <summary>
+    /// The parser Recursive(() => p) behaves like p while enabling p to be recursive.
+    /// </summary>
+    public static Parser<TItem, TValue> Recursive<TItem, TValue>(Func<Parser<TItem, TValue>> getRecursiveParser)
+    {
+        var delayedParserReference = new Lazy<Parser<TItem, TValue>>(getRecursiveParser);
+
+        return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation)
+            => delayedParserReference.Value(input, ref index, out succeeded, out expectation);
+    }
+}

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -259,5 +259,49 @@ partial class Grammar
             return null;
         };
     }
+
+    public static Parser<TItem, IReadOnlyList<TItem>> ZeroOrMore<TItem>(Func<TItem, bool> test)
+    {
+        return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
+        {
+            var length = input.CountWhile(index, test);
+            
+            if (length > 0)
+            {
+                var slice = input.Slice(index, length);
+                index += length;
+
+                expectation = null;
+                succeeded = true;
+                return slice.ToArray();
+            }
+
+            expectation = null;
+            succeeded = true;
+            return Array.Empty<TItem>();
+        };
+    }
+
+    public static Parser<TItem, IReadOnlyList<TItem>> OneOrMore<TItem>(Func<TItem, bool> test, string name)
+    {
+        return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
+        {
+            var length = input.CountWhile(index, test);
+
+            if (length > 0)
+            {
+                var span = input.Slice(index, length);
+                index += length;
+
+                expectation = null;
+                succeeded = true;
+                return span.ToArray();
+            }
+
+            expectation = name;
+            succeeded = false;
+            return null;
+        };
+    }
 }
 

--- a/src/Parsley/ParseError.cs
+++ b/src/Parsley/ParseError.cs
@@ -1,0 +1,3 @@
+namespace Parsley;
+
+public record ParseError(int Index, string Expectation);

--- a/src/Parsley/ParserExtensions.cs
+++ b/src/Parsley/ParserExtensions.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Parsley;
+
+public static class ParserExtensions
+{
+    public static bool TryParse<TItem, TValue>(
+        this Parser<TItem, TValue> parse,
+        ReadOnlySpan<TItem> input,
+        [NotNullWhen(true)] out TValue? value,
+        [NotNullWhen(false)] out ParseError? error)
+    {
+        var parseToEnd =
+            from result in parse
+            from end in Grammar.EndOfInput<TItem>()
+            select result;
+
+        return TryPartialParse(parseToEnd, input, out int index, out value, out error);
+    }
+
+    public static bool TryPartialParse<TItem, TValue>(
+        this Parser<TItem, TValue> parse,
+        ReadOnlySpan<TItem> input,
+        out int index,
+        [NotNullWhen(true)] out TValue? value,
+        [NotNullWhen(false)] out ParseError? error)
+    {
+        index = 0;
+        value = parse(input, ref index, out var succeeded, out var expectation);
+
+        if (succeeded)
+        {
+            error = null;
+            #pragma warning disable CS8762 // Parameter must have a non-null value when exiting in some condition.
+            return true;
+            #pragma warning restore CS8762 // Parameter must have a non-null value when exiting in some condition.
+        }
+
+        error = new ParseError(index, expectation!);
+        return false;
+    }
+}


### PR DESCRIPTION
This takes advantage of recent item-type generalization, to demonstrate how it can be used to create a parser with more than one 'phase'.

Recent work enhanced the ability to describe parsing patterns against spans of any item type, not just the char spans of a given string input.

To demonstrate the purpose, this rephrases the JSON parser example so that it becomes a "two phase" parser: the first phase processes the sequence of char, resulting in a sequence of custom Token objects, and the second phase has parsers written in terms of the Token sequence resulting in C# objects equivalent to the intent of the JSON.

One of the benefits of having a separate tokenization phase is that it is easier to express the impact of optional whitespace sequences. Here they are only of concern during the tokenization phase *and discarded*, so that the rest of the grammar can focus on meaningful tokens rather than frequently having to concern itself with possible whitespace throughout.