### PR TITLE
Fast Sequences

### DIFF
--- a/src/Parsley.Tests/MapTests.cs
+++ b/src/Parsley.Tests/MapTests.cs
@@ -1,0 +1,109 @@
+using System.Globalization;
+using static Parsley.Grammar;
+
+namespace Parsley.Tests;
+
+class MapTests
+{
+    static readonly Parser<char, char> Next = Single<char>(_ => true, "character");
+
+    static readonly Parser<char, string> Fail = (ReadOnlySpan<char> input, ref int index, out bool succeeded, out string? expectation) =>
+    {
+        expectation = "unsatisfiable expectation";
+        succeeded = false;
+        return null;
+    };
+
+    public void CanMapOneParser()
+    {
+        Map(Next, x => char.ToUpper(x, CultureInfo.InvariantCulture))
+            .PartiallyParses("xy", "y").ShouldBe('X');
+
+        Map(Fail, x => x)
+            .FailsToParse("xy", "xy", "unsatisfiable expectation expected");
+    }
+
+    public void CanMapTwoParsers()
+    {
+        Map(Next, Next,
+                (a, b) => $"{a}{b}".ToUpper(CultureInfo.InvariantCulture))
+            .PartiallyParses("abcdef", "cdef").ShouldBe("AB");
+
+        Map(Fail, Next,
+                (_, x) => x)
+            .FailsToParse("xy", "xy", "unsatisfiable expectation expected");
+
+        Map(Next, Fail,
+                (x, _) => x)
+            .FailsToParse("xy", "y", "unsatisfiable expectation expected");
+    }
+
+    public void CanMapThreeParsers()
+    {
+        Map(Next, Next, Next,
+                (a, b, c) => $"{a}{b}{c}".ToUpper(CultureInfo.InvariantCulture))
+            .PartiallyParses("abcdef", "def").ShouldBe("ABC");
+
+        Map(Fail, Next, Next,
+                (_, x, y) => (x, y))
+            .FailsToParse("xy", "xy", "unsatisfiable expectation expected");
+
+        Map(Next, Fail, Next,
+            (x, _, y) => (x, y))
+                .FailsToParse("xy", "y", "unsatisfiable expectation expected");
+
+        Map(Next, Next, Fail,
+                (x, y, _) => (x, y))
+            .FailsToParse("xy", "", "unsatisfiable expectation expected");
+    }
+
+    public void CanMapFourParsers()
+    {
+        Map(Next, Next, Next, Next,
+                (a, b, c, d) => $"{a}{b}{c}{d}".ToUpper(CultureInfo.InvariantCulture))
+            .PartiallyParses("abcdef", "ef").ShouldBe("ABCD");
+
+        Map(Fail, Next, Next, Next,
+                (_, x, y, z) => (x, y, z))
+            .FailsToParse("xyz", "xyz", "unsatisfiable expectation expected");
+
+        Map(Next, Fail, Next, Next,
+                (x, _, y, z) => (x, y, z))
+            .FailsToParse("xyz", "yz", "unsatisfiable expectation expected");
+
+        Map(Next, Next, Fail, Next,
+                (x, y, _, z) => (x, y, z))
+            .FailsToParse("xyz", "z", "unsatisfiable expectation expected");
+
+        Map(Next, Next, Next, Fail,
+                (x, y, z, _) => (x, y, z))
+            .FailsToParse("xyz", "", "unsatisfiable expectation expected");
+    }
+
+    public void CanMapFiveParsers()
+    {
+        Map(Next, Next, Next, Next, Next,
+                (a, b, c, d, e) => $"{a}{b}{c}{d}{e}".ToUpper(CultureInfo.InvariantCulture))
+            .PartiallyParses("abcdef", "f").ShouldBe("ABCDE");
+
+        Map(Fail, Next, Next, Next, Next,
+                (_, w, x, y, z) => (w, x, y, z))
+            .FailsToParse("wxyz", "wxyz", "unsatisfiable expectation expected");
+
+        Map(Next, Fail, Next, Next, Next,
+                (w, _, x, y, z) => (w, x, y, z))
+            .FailsToParse("wxyz", "xyz", "unsatisfiable expectation expected");
+
+        Map(Next, Next, Fail, Next, Next,
+                (w, x, _, y, z) => (w, x, y, z))
+            .FailsToParse("wxyz", "yz", "unsatisfiable expectation expected");
+
+        Map(Next, Next, Next, Fail, Next,
+                (w, x, y, _, z) => (w, x, y, z))
+            .FailsToParse("wxyz", "z", "unsatisfiable expectation expected");
+
+        Map(Next, Next, Next, Next, Fail,
+                (w, x, y, z, _) => (w, x, y, z))
+            .FailsToParse("wxyz", "", "unsatisfiable expectation expected");
+    }
+}

--- a/src/Parsley.Tests/ParserQueryTests.cs
+++ b/src/Parsley.Tests/ParserQueryTests.cs
@@ -44,16 +44,16 @@ class ParserQueryTests
         (from _ in Fail
             from x in Next
             from y in Next
-            select Tuple.Create(x, y)).FailsToParse("xy", "xy", "unsatisfiable expectation expected");
+            select (x, y)).FailsToParse("xy", "xy", "unsatisfiable expectation expected");
 
         (from x in Next
             from _ in Fail
             from y in Next
-            select Tuple.Create(x, y)).FailsToParse("xy", "y", "unsatisfiable expectation expected");
+            select (x, y)).FailsToParse("xy", "y", "unsatisfiable expectation expected");
 
         (from x in Next
             from y in Next
             from _ in Fail
-            select Tuple.Create(x, y)).FailsToParse("xy", "", "unsatisfiable expectation expected");
+            select (x, y)).FailsToParse("xy", "", "unsatisfiable expectation expected");
     }
 }

--- a/src/Parsley/Grammar.Between.cs
+++ b/src/Parsley/Grammar.Between.cs
@@ -5,44 +5,10 @@ partial class Grammar
     /// <summary>
     /// Between(left, goal, right) parses its arguments in order.  If all three
     /// parsers succeed, the result of the goal parser is returned.
-    ///
-    /// <para>Between is an optimized version of the query:</para>
-    ///
-    /// <code>
-    ///     from L in left
-    ///     from G in goal
-    ///     from R in right
-    ///     select G
-    /// </code>
     /// </summary>
     public static Parser<TItem, TGoal> Between<TItem, TLeft, TGoal, TRight>(
         Parser<TItem, TLeft> left,
         Parser<TItem, TGoal> goal,
         Parser<TItem, TRight> right)
-    {
-        return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
-        {
-            left(input, ref index, out succeeded, out expectation);
-
-            if (succeeded)
-            {
-                var goalValue = goal(input, ref index, out succeeded, out expectation);
-
-                if (succeeded)
-                {
-                    right(input, ref index, out succeeded, out expectation);
-
-                    if (succeeded)
-                    {
-                        expectation = null;
-                        succeeded = true;
-                        return goalValue;
-                    }
-                }
-            }
-
-            succeeded = false;
-            return default;
-        };
-    }
+        => Map(left, goal, right, (_, g, _) => g);
 }

--- a/src/Parsley/Grammar.Map.cs
+++ b/src/Parsley/Grammar.Map.cs
@@ -1,0 +1,199 @@
+namespace Parsley;
+
+partial class Grammar
+{
+    public static Parser<TItem, TValue> Map<TItem, T1, TValue>(
+        Parser<TItem, T1> parser1,
+        Func<T1, TValue> combineIntermediateResults)
+    {
+        return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
+        {
+            var value1 = parser1(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            expectation = null;
+            succeeded = true;
+
+            return combineIntermediateResults(value1!);
+        };
+    }
+
+    public static Parser<TItem, TValue> Map<TItem, T1, T2, TValue>(
+        Parser<TItem, T1> parser1,
+        Parser<TItem, T2> parser2,
+        Func<T1, T2, TValue> combineIntermediateResults)
+    {
+        return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
+        {
+            var value1 = parser1(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            var value2 = parser2(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            expectation = null;
+            succeeded = true;
+
+            return combineIntermediateResults(value1!, value2!);
+        };
+    }
+
+    public static Parser<TItem, TValue> Map<TItem, T1, T2, T3, TValue>(
+        Parser<TItem, T1> parser1,
+        Parser<TItem, T2> parser2,
+        Parser<TItem, T3> parser3,
+        Func<T1, T2, T3, TValue> combineIntermediateResults)
+    {
+        return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
+        {
+            var value1 = parser1(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            var value2 = parser2(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            var value3 = parser3(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            expectation = null;
+            succeeded = true;
+
+            return combineIntermediateResults(value1!, value2!, value3!);
+        };
+    }
+
+    public static Parser<TItem, TValue> Map<TItem, T1, T2, T3, T4, TValue>(
+        Parser<TItem, T1> parser1,
+        Parser<TItem, T2> parser2,
+        Parser<TItem, T3> parser3,
+        Parser<TItem, T4> parser4,
+        Func<T1, T2, T3, T4, TValue> combineIntermediateResults)
+    {
+        return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
+        {
+            var value1 = parser1(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            var value2 = parser2(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            var value3 = parser3(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            var value4 = parser4(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            expectation = null;
+            succeeded = true;
+
+            return combineIntermediateResults(value1!, value2!, value3!, value4!);
+        };
+    }
+
+    public static Parser<TItem, TValue> Map<TItem, T1, T2, T3, T4, T5, TValue>(
+        Parser<TItem, T1> parser1,
+        Parser<TItem, T2> parser2,
+        Parser<TItem, T3> parser3,
+        Parser<TItem, T4> parser4,
+        Parser<TItem, T5> parser5,
+        Func<T1, T2, T3, T4, T5, TValue> combineIntermediateResults)
+    {
+        return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
+        {
+            var value1 = parser1(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            var value2 = parser2(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            var value3 = parser3(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            var value4 = parser4(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            var value5 = parser5(input, ref index, out succeeded, out expectation);
+
+            if (!succeeded)
+            {
+                succeeded = false;
+                return default;
+            }
+
+            expectation = null;
+            succeeded = true;
+
+            return combineIntermediateResults(value1!, value2!, value3!, value4!, value5!);
+        };
+    }
+}

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -80,9 +80,7 @@ partial class Grammar
             }
 
             var separatorAndNextItem =
-                from _ in separator
-                from next in item
-                select next;
+                Map(separator, item, (_, next) => next);
 
             return Repeat(accumulator, separatorAndNextItem, input, ref index, out succeeded, out expectation);
         };
@@ -112,9 +110,7 @@ partial class Grammar
             }
 
             var separatorAndNextItem =
-                from _ in separator
-                from next in item
-                select next;
+                Map(separator, item, (_, next) => next);
 
             return Repeat(accumulator, separatorAndNextItem, input, ref index, out succeeeded, out expectation);
         };

--- a/src/Parsley/ParserExtensions.cs
+++ b/src/Parsley/ParserExtensions.cs
@@ -11,9 +11,7 @@ public static class ParserExtensions
         [NotNullWhen(false)] out ParseError? error)
     {
         var parseToEnd =
-            from result in parse
-            from end in Grammar.EndOfInput<TItem>()
-            select result;
+            Grammar.Map(parse, Grammar.EndOfInput<TItem>(), (result, _) => result);
 
         return TryPartialParse(parseToEnd, input, out int index, out value, out error);
     }


### PR DESCRIPTION
Parser queries have always allowed for building up a new parser from a series of other parsers:

```cs
var combinedParser =
   from x in P1
   from y in P2
   from z in P3
   select BuildSomeValue(x, y, z);
```

This runs parser P1 against the input and holds the resulting value in x, and then continues from that position to run parser P2 against the remaining input and holds the resulting value in y, and then continues from that position to run parser P3 against the remaining input and holds the resulting value in z. If all 3 parsers succeed then the result of the combined parser is the value selected. If any of the 3 parsers fail then the combined parser fails at the position of the failing component parser and with the failing component parser's expectation.

These are concise, support an arbitrary number of component parts, and get the intermediate variable names (x, y, z) physically close to the component parser (P1, P2, P3) they come from. However, they are incredibly slow due to the extreme number of implicit lambda expressions, functions calls, and bookkeeping behind the support of the query syntax. The costs can add up under heavy load when a query in question needs to run many times throughout the parsing of a large input.

This PR introduces optimized alternatives for up to 5 component parsers. The downside is that the user has to think a little harder to visually align each component parser with the intermediate results' names:

```
Map(P1, P2, P3, (x, y, z) => BuildSomeValue(x, y, z));
```

The `Map` overloads are used throughout the implementation of other parser primitives, so that end users are only impacted by their own choice of query syntax.