### PR TITLE
Add benchmarks parsing a representative subset of JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /src/**/bin/
 /src/**/obj/
 /src/**/*.csproj.user
+/BenchmarkDotNet.Artifacts/

--- a/benchmark
+++ b/benchmark
@@ -1,0 +1,1 @@
+pwsh ./eng/benchmark.ps1 "$@"

--- a/eng/benchmark.ps1
+++ b/eng/benchmark.ps1
@@ -1,0 +1,3 @@
+. (Join-Path $PSScriptRoot utilities)
+
+exec { dotnet run -c Release --project src/Parsley.Benchmark }

--- a/src/Parsley.Benchmark/JsonBenchmarks.cs
+++ b/src/Parsley.Benchmark/JsonBenchmarks.cs
@@ -1,0 +1,45 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+
+namespace Parsley.Benchmark;
+
+[MemoryDiagnoser, GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByParams)]
+public class JsonBenchmarks
+{
+    public static IEnumerable<SampleJson> Scenarios()
+    {
+        yield return new SampleJson("Typical", length: 10, depth: 3);
+        yield return new SampleJson("Repetition", length: 256, depth: 1);
+        yield return new SampleJson("Recursion", length: 1, depth: 256);
+    }
+
+    [Benchmark(Description = "System.Text.Json", Baseline = true)]
+    [ArgumentsSource(nameof(Scenarios))]
+    public object? SystemTextJson(SampleJson sample)
+        => System.Text.Json.JsonSerializer.Deserialize<object?>(sample.Json, systemJsonOptions);
+
+    [Benchmark(Description = "Newtonsoft.Json")]
+    [ArgumentsSource(nameof(Scenarios))]
+    public object? NewtonsoftJson(SampleJson sample)
+        => Newtonsoft.Json.JsonConvert.DeserializeObject<object?>(sample.Json, newtonsoftJsonOptions);
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Scenarios))]
+    public object? Parsley(SampleJson sample)
+        => ParsleyJsonParser.Parse(sample.Json);
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Scenarios))]
+    public object? Pidgin(SampleJson sample)
+        => PidginJsonParser.Parse(sample.Json);
+
+    static readonly System.Text.Json.JsonSerializerOptions systemJsonOptions = new()
+    {
+        MaxDepth = 1000
+    };
+
+    static readonly Newtonsoft.Json.JsonSerializerSettings newtonsoftJsonOptions = new()
+    {
+        MaxDepth = 1000
+    };
+}

--- a/src/Parsley.Benchmark/Parsley.Benchmark.csproj
+++ b/src/Parsley.Benchmark/Parsley.Benchmark.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Pidgin" Version="3.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Parsley\Parsley.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Parsley.Benchmark/ParsleyJsonParser.cs
+++ b/src/Parsley.Benchmark/ParsleyJsonParser.cs
@@ -1,0 +1,65 @@
+using static Parsley.Grammar;
+using static Parsley.Characters;
+
+namespace Parsley.Benchmark;
+
+public static class ParsleyJsonParser
+{
+    static Parser<char, object?> Literal(string literal, object? value)
+        => Map(Keyword(literal), _ => value);
+
+    static readonly Parsley.Parser<char, Void> SkipWhitespaces = Skip(IsWhiteSpace);
+
+    static readonly Parsley.Parser<char, string> String =
+        Between(Single('"'), ZeroOrMore(c => c != '"'), Single('"'));
+
+    static readonly Parsley.Parser<char, object?> Json =
+        Recursive(() =>
+        {
+            var @true = Literal("true", true);
+            var @false = Literal("false", false);
+            var @null = Literal("null", null);
+            var @int = Map(OneOrMore(IsDigit, "digit"), digits => (object?) int.Parse(digits));
+
+            return Choice(@true, @false, @null, @int, String, Array, Object);
+        });
+
+    static Parsley.Parser<char, object> Array =>
+        List('[', Json, ']', items => items.ToArray());
+
+    static Parsley.Parser<char, object> Object
+    {
+        get
+        {
+            var ColonWhitespace =
+                Between(SkipWhitespaces, Single(':'), SkipWhitespaces);
+
+            var Pair =
+                Map(String, ColonWhitespace, Json,
+                    (name, _, val) => new KeyValuePair<string, object?>(name, val));
+
+            return List('{', Pair, '}',
+                pairs => new Dictionary<string, object?>(pairs));
+        }
+    }
+
+    static Parser<char, TValue> List<TItem, TValue>(
+        char open,
+        Parsley.Parser<char, TItem> item,
+        char close,
+        Func<IReadOnlyList<TItem>, TValue> convert) =>
+        Map(
+            Between(
+                Single(open),
+                ZeroOrMore(Between(SkipWhitespaces, item, SkipWhitespaces), Single(',')),
+                Single(close)),
+            convert);
+
+    public static object? Parse(string input)
+    {
+        if (Json.TryParse(input, out object? value, out var error))
+            return value;
+
+        throw new Exception(error.Expectation + " expected");
+    }
+}

--- a/src/Parsley.Benchmark/PidginJsonParser.cs
+++ b/src/Parsley.Benchmark/PidginJsonParser.cs
@@ -1,0 +1,55 @@
+using Pidgin;
+using static Pidgin.Parser;
+using static Pidgin.Parser<char>;
+
+namespace Parsley.Benchmark;
+
+public static class PidginJsonParser
+{
+    static Pidgin.Parser<char, object?> Literal(string literal, object? value)
+        => Map(_ => value, String(literal));
+
+    static readonly Pidgin.Parser<char, string> String =
+        Token(c => c != '"').ManyString().Between(Char('"'));
+
+    static readonly Pidgin.Parser<char, object?> Json =
+        Rec(() =>
+        {
+            var @true = Literal("true", true);
+            var @false = Literal("false", false);
+            var @null = Literal("null", null);
+            var @int = Map(digits => (object?)int.Parse(digits), Digit.AtLeastOnceString());
+
+            return OneOf(@true, @false, @null, @int, String.Cast<object?>(), Array!, Object!);
+        });
+
+    static readonly Pidgin.Parser<char, object?> Array =
+        List('[', Json, ']', items => (object?)items.ToArray());
+
+    static Pidgin.Parser<char, object?> Object
+    {
+        get
+        {
+            var ColonWhitespace = Char(':').Between(SkipWhitespaces);
+
+            var Pair =
+                String
+                    .Before(ColonWhitespace)
+                    .Then(Json, (name, val) => new KeyValuePair<string, object?>(name, val));
+
+            return List('{', Pair, '}', pairs => (object?) new Dictionary<string, object?>(pairs));
+        }
+    }
+
+    static Pidgin.Parser<char, TValue> List<TItem, TValue>(
+        char open,
+        Pidgin.Parser<char, TItem> item,
+        char close,
+        Func<IEnumerable<TItem>, TValue> convert) =>
+        item.Between(SkipWhitespaces)
+            .Separated(Char(','))
+            .Between(Char(open), Char(close))
+            .Select(convert);
+
+    public static Result<char, object?> Parse(string input) => Json.Parse(input);
+}

--- a/src/Parsley.Benchmark/Program.cs
+++ b/src/Parsley.Benchmark/Program.cs
@@ -1,0 +1,11 @@
+using BenchmarkDotNet.Running;
+
+namespace Parsley.Benchmark;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        var summary = BenchmarkRunner.Run(typeof(Program).Assembly);
+    }
+}

--- a/src/Parsley.Benchmark/SampleJson.cs
+++ b/src/Parsley.Benchmark/SampleJson.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+
+namespace Parsley.Benchmark;
+
+public class SampleJson
+{
+    static readonly Random random = new();
+
+    static readonly JsonSerializerOptions serializerOptions = new()
+    {
+        WriteIndented = true,
+        MaxDepth = 1000
+    };
+
+    readonly string scenario;
+    public string Json { get; }
+
+    public SampleJson(string scenario, int length, int depth)
+    {
+        this.scenario = scenario;
+
+        var list = new List<object>(length);
+
+        for (int i = 1; i <= length; i++)
+            list.Add(BuildObject(depth));
+
+        Json = JsonSerializer.Serialize(list, serializerOptions);
+    }
+
+    public override string ToString() => scenario;
+
+    static string RandomString() => Guid.NewGuid().ToString();
+    
+    static object BuildObject(int depth)
+        => depth == 1
+            ? new Leaf()
+            : new Branch { Inner = BuildObject(depth - 1) };
+
+    class Branch
+    {
+        public object? Inner { get; set; }
+    }
+
+    class Leaf
+    {
+        public string First { get; init; } = RandomString();
+        public string Second { get; init; } = RandomString();
+        public string Third { get; init; } = RandomString();
+        public bool Boolean { get; init; } = random.NextDouble() > 0.5;
+        public int Integer { get; init; } = random.Next(0, int.MaxValue);
+        public object? Null { get; init; }
+    }
+}

--- a/src/Parsley.sln
+++ b/src/Parsley.sln
@@ -1,19 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32421.90
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Parsley", "Parsley\Parsley.csproj", "{3D567EDB-1DB6-4B2B-AC9A-EEE63D5BA806}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Parsley", "Parsley\Parsley.csproj", "{3D567EDB-1DB6-4B2B-AC9A-EEE63D5BA806}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Parsley.Tests", "Parsley.Tests\Parsley.Tests.csproj", "{02C7A22E-1A63-478F-915E-4C7F6EF50B05}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Parsley.Tests", "Parsley.Tests\Parsley.Tests.csproj", "{02C7A22E-1A63-478F-915E-4C7F6EF50B05}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Parsley.Benchmark", "Parsley.Benchmark\Parsley.Benchmark.csproj", "{EC3CB54A-0114-47DC-8BA1-E80A63780F87}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{3D567EDB-1DB6-4B2B-AC9A-EEE63D5BA806}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -24,5 +23,15 @@ Global
 		{02C7A22E-1A63-478F-915E-4C7F6EF50B05}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{02C7A22E-1A63-478F-915E-4C7F6EF50B05}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{02C7A22E-1A63-478F-915E-4C7F6EF50B05}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC3CB54A-0114-47DC-8BA1-E80A63780F87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC3CB54A-0114-47DC-8BA1-E80A63780F87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC3CB54A-0114-47DC-8BA1-E80A63780F87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC3CB54A-0114-47DC-8BA1-E80A63780F87}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {20F40252-56E5-48B0-966A-A235C0F69BB1}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Here we have two equivalent parsers for a subset of JSON, one written with Parsley and one written with the similar and highly optimized Pidgin library. For additional context, the same measurements are taken against System.Text.Json and Newtonsoft.Json, to see how impactful it is to have a custom parser vs using a parser combinator library.

3 representative JSON documents are parsed here: a 'typical' document with a handful of objects and a few levels of nesting, a 'repetition' document in which there is a *long* array of objects (putting pressure on each library's ability to accumulate N items), and a 'recursion' document in which there is a *deeply nested* object (putting pressure on each library's recursion or other equivalent depth handling scheme).

The deeply nested case is a bit pathological: this is not typically encountered in the wild and Newtonsoft/System.Text.Json both *refuse* by default as a safety measure for denial-of-service attacks. 

In each case, System.Text.Json is treated as the baseline. 

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1706 (21H1/May2021Update)
Intel Core i7-3770K CPU 3.50GHz (Ivy Bridge), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.203
  [Host]     : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT
  DefaultJob : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT
```

|           Method |     Sample |        Mean | Ratio |    Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|----------------- |----------- |------------:|------:|---------:|--------:|--------:|----------:|
| **System.Text.Json** |  **Recursion** |   **718.77 μs** |  **1.00** |  **42.9688** | **41.0156** | **41.0156** |    **145 KB** |
|  Newtonsoft.Json |  Recursion |   407.39 μs |  0.57 |  37.5977 | 12.6953 |       - |    181 KB |
|          Parsley |  Recursion |   659.41 μs |  0.92 |  42.9688 |  5.8594 |       - |    176 KB |
|           Pidgin |  Recursion |   539.94 μs |  0.75 |  55.6641 |  1.9531 |       - |    229 KB |

|           Method |     Sample |        Mean | Ratio |    Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|----------------- |----------- |------------:|------:|---------:|--------:|--------:|----------:|
| **System.Text.Json** | **Repetition** |   **335.25 μs** |  **1.00** |  **24.9023** |  **5.8594** |       **-** |    **103 KB** |
|  Newtonsoft.Json | Repetition | 1,109.42 μs |  3.31 | 103.5156 | 50.7813 |       - |    641 KB |
|          Parsley | Repetition |   783.70 μs |  2.34 |  94.7266 | 39.0625 |       - |    506 KB |
|           Pidgin | Repetition | 1,845.21 μs |  5.50 |  56.6406 | 25.3906 |       - |    311 KB |

|           Method |     Sample |        Mean | Ratio |    Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|----------------- |----------- |------------:|------:|---------:|--------:|--------:|----------:|
| **System.Text.Json** |    **Typical** |    **18.66 μs** |  **1.00** |   **1.3733** |       **-** |       **-** |      **6 KB** |
|  Newtonsoft.Json |    Typical |    54.57 μs |  2.92 |   9.7656 |  0.8545 |       - |     40 KB |
|          Parsley |    Typical |    43.71 μs |  2.34 |   8.2397 |       - |       - |     34 KB |
|           Pidgin |    Typical |    97.30 μs |  5.22 |   5.0049 |       - |       - |     20 KB |

Overall, Parsley competes well with Newtonsoft.Json and Pidgin in terms of speed, though appears to have a larger memory footprint than Pidgin, which is interesting as the two parsers are written to be as much like each other as possible.