### PR TITLE
Memory efficiency for the Choice combinator.

### DIFF
--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -571,6 +571,18 @@ public class AlternationTests
         Choice(C, B, A).Parses("A").ShouldBe("A");
     }
 
+    public void ProvidesLastMissedExpectationWhenParsersFailWithoutConsumingInput()
+    {
+        Choice(A, B).FailsToParse("", "", "B expected");
+        Choice(A, B, C).FailsToParse("", "", "C expected");
+    }
+
+    public void SupportsOptionalComprehensiveExpectationsWhenAllParsersFailWithoutConsumingInput()
+    {
+        Choice("A or B", A, B).FailsToParse("", "", "A or B expected");
+        Choice("A, B, or C", A, B, C).FailsToParse("", "", "A, B, or C expected");
+    }
+
     public void SubsequentParserWillNotBeAttemptedWhenPreviousParserFailsAfterConsumingInput()
     {
         //As soon as something consumes input, it's failure and message win.
@@ -583,10 +595,16 @@ public class AlternationTests
         Choice(C, AB, NeverExecuted).FailsToParse("A", "", "B expected");
     }
 
-    public void MergesErrorMessagesWhenParsersFailWithoutConsumingInput()
+    public void SpecificExpectationSupercedesComprehensiveExpectationWhenAnyParserFailsAfterConsumingInput()
     {
-        Choice(A, B).FailsToParse("", "", "(A or B) expected");
-        Choice(A, B, C).FailsToParse("", "", "(A, B, or C) expected");
+        //As soon as something consumes input, it's failure and message win.
+
+        var AB = from a in A
+            from b in B
+            select $"{a}{b}";
+
+        Choice("This expectation is discarded.", AB, NeverExecuted).FailsToParse("A", "", "B expected");
+        Choice("This expectation is discarded.", C, AB, NeverExecuted).FailsToParse("A", "", "B expected");
     }
 
     public void MergesPotentialErrorMessagesWhenParserSucceedsWithoutConsumingInput()

--- a/src/Parsley.Tests/IntegrationTests/Json/Json.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/Json.cs
@@ -154,7 +154,7 @@ public class Json
 
             var charactersFromEscapeSequence =
                 from slash in Single('\\')
-                from unescaped in Choice(escapeCharacter, unicodeEscapeCharacters)
+                from unescaped in Choice("escape sequence", escapeCharacter, unicodeEscapeCharacters)
                 select unescaped;
 
             var literalCharacters =

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonTests.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonTests.cs
@@ -128,7 +128,7 @@ class JsonTests
             @"parent"": false
                     }
                 }",
-            "(escape character or unicode escape sequence) expected");
+            "escape sequence expected");
     }
 
     public void ProvidesUsefulErrorMessagesForDeeplyPlacedGrammarErrors()


### PR DESCRIPTION
The Choice combinator no longer repeatedly builds a worst-case comprehensive expectation string. Supporting such a string involved building up a likely-redundant list of possible expectation parts on every execution of the choice, even when they would be frequently discarded without being used in the case of success. In the case they were in fact used, the end user would be better served with a user-specified name rather than a silly automatic expectation like "A or B or C or D or E or F expected".

# Before

|           Method |     sample |        Mean | Ratio |    Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|----------------- |----------- |------------:|------:|---------:|--------:|--------:|----------:|
| System.Text.Json |  Recursion |   748.42 us |  1.00 |  42.9688 | 41.0156 | 41.0156 |    145 KB |
|  Newtonsoft.Json |  Recursion |   413.07 us |  0.55 |  37.5977 | 12.6953 |       - |    181 KB |
|          **Parsley** |  Recursion |   **670.73 us** |  0.90 |  42.9688 |  4.8828 |       - |    **176 KB** |
|           Pidgin |  Recursion |   552.05 us |  0.74 |  55.6641 |  1.9531 |       - |    229 KB |
|                  |            |             |       |          |         |         |           |
| System.Text.Json | Repetition |   336.66 us |  1.00 |  24.9023 |  5.8594 |       - |    103 KB |
|  Newtonsoft.Json | Repetition | 1,152.15 us |  3.42 | 103.5156 | 50.7813 |       - |    641 KB |
|          **Parsley** | Repetition |   **792.17 us** |  2.35 |  91.7969 | 32.2266 |       - |    **507 KB** |
|           Pidgin | Repetition | 1,909.65 us |  5.67 |  56.6406 | 25.3906 |       - |    311 KB |
|                  |            |             |       |          |         |         |           |
| System.Text.Json |    Typical |    19.16 us |  1.00 |   1.3733 |       - |       - |      6 KB |
|  Newtonsoft.Json |    Typical |    54.51 us |  2.84 |   9.7656 |  1.5259 |       - |     40 KB |
|          **Parsley** |    Typical |    **44.51 us** |  2.32 |   8.3008 |  0.4883 |       - |     **34 KB** |
|           Pidgin |    Typical |    97.95 us |  5.11 |   5.0049 |       - |       - |     20 KB |

# After

|           Method |     sample |        Mean | Ratio |    Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|----------------- |----------- |------------:|------:|---------:|--------:|--------:|----------:|
| System.Text.Json |  Recursion |   722.74 us |  1.00 |  42.9688 | 41.0156 | 41.0156 |    145 KB |
|  Newtonsoft.Json |  Recursion |   413.05 us |  0.57 |  37.5977 | 12.6953 |       - |    181 KB |
|          **Parsley** |  Recursion |   **630.76 us** |  0.87 |  31.2500 |  0.9766 |       - |    **131 KB** |
|           Pidgin |  Recursion |   551.00 us |  0.76 |  55.6641 |  1.9531 |       - |    229 KB |
|                  |            |             |       |          |         |         |           |
| System.Text.Json | Repetition |   338.95 us |  1.00 |  24.9023 |  5.8594 |       - |    103 KB |
|  Newtonsoft.Json | Repetition | 1,140.12 us |  3.36 | 103.5156 | 50.7813 |       - |    641 KB |
|          **Parsley** | Repetition |   **686.46 us** |  2.03 |  62.5000 | 27.3438 |       - |    **337 KB** |
|           Pidgin | Repetition | 1,897.00 us |  5.60 |  56.6406 | 25.3906 |       - |    311 KB |
|                  |            |             |       |          |         |         |           |
| System.Text.Json |    Typical |    19.02 us |  1.00 |   1.3733 |       - |       - |      6 KB |
|  Newtonsoft.Json |    Typical |    54.64 us |  2.87 |   9.7656 |  1.1597 |       - |     40 KB |
|          **Parsley** |    Typical |    **38.74 us** |  2.04 |   5.7983 |       - |       - |     **24 KB** |
|           Pidgin |    Typical |    96.94 us |  5.10 |   5.0049 |       - |       - |     21 KB |