### PR TITLE
Span aware repetition parsers

### DIFF
--- a/src/Parsley.Benchmark/ParsleyJsonParser.cs
+++ b/src/Parsley.Benchmark/ParsleyJsonParser.cs
@@ -11,7 +11,7 @@ public static class ParsleyJsonParser
     static readonly Parsley.Parser<char, Void> SkipWhitespaces = Skip(IsWhiteSpace);
 
     static readonly Parsley.Parser<char, string> String =
-        Between(Single('"'), ZeroOrMore(c => c != '"'), Single('"'));
+        Between(Single('"'), ZeroOrMore((char c) => c != '"', span => span.ToString()), Single('"'));
 
     static readonly Parsley.Parser<char, object?> Json =
         Recursive(() =>
@@ -19,7 +19,7 @@ public static class ParsleyJsonParser
             var @true = Literal("true", true);
             var @false = Literal("false", false);
             var @null = Literal("null", null);
-            var @int = Map(OneOrMore(IsDigit, "digit"), digits => (object?) int.Parse(digits));
+            var @int = Map(OneOrMore(IsDigit, "digit", span => span.ToString()), digits => (object?) int.Parse(digits));
 
             return Choice(@true, @false, @null, @int, String, Array, Object);
         });

--- a/src/Parsley.Benchmark/ParsleyJsonParser.cs
+++ b/src/Parsley.Benchmark/ParsleyJsonParser.cs
@@ -19,7 +19,7 @@ public static class ParsleyJsonParser
             var @true = Literal("true", true);
             var @false = Literal("false", false);
             var @null = Literal("null", null);
-            var @int = Map(OneOrMore(IsDigit, "digit", span => span.ToString()), digits => (object?) int.Parse(digits));
+            var @int = OneOrMore(IsDigit, "digit", digits => (object?) int.Parse(digits));
 
             return Choice(@true, @false, @null, @int, String, Array, Object);
         });

--- a/src/Parsley.Tests/GrammarTests.cs
+++ b/src/Parsley.Tests/GrammarTests.cs
@@ -256,9 +256,9 @@ class GrammarTests
 
     public void ProvidesConveniencePrimitiveRecognizingOptionalSequencesOfItemsSatisfyingSomePredicate()
     {
-        var lower = ZeroOrMore(IsLower);
-        var upper = ZeroOrMore(IsUpper);
-        var caseInsensitive = ZeroOrMore(IsLetter);
+        var lower = ZeroOrMore(IsLower, span => span.ToString());
+        var upper = ZeroOrMore(IsUpper, span => span.ToString());
+        var caseInsensitive = ZeroOrMore(IsLetter, span => span.ToString());
 
         lower.Parses("").ShouldBe("");
 
@@ -274,7 +274,8 @@ class GrammarTests
 
         caseInsensitive.Parses("abcDEF").ShouldBe("abcDEF");
 
-        var even = ZeroOrMore<int>(x => x % 2 == 0);
+        var isEven = (int x) => x % 2 == 0;
+        var even = ZeroOrMore(isEven, span => span.ToArray());
         var empty = Array.Empty<int>();
         even.Parses(empty).ShouldBe(empty);
         even.PartiallyParses(new[] { 1, 2, 4, 6 }, new[] { 1, 2, 4, 6 }).ShouldBe(empty);
@@ -284,9 +285,9 @@ class GrammarTests
 
     public void ProvidesConveniencePrimitiveRecognizingNonemptySequencesOfItemsSatisfyingSomePredicate()
     {
-        var lower = OneOrMore(IsLower, "Lowercase");
-        var upper = OneOrMore(IsUpper, "Uppercase");
-        var caseInsensitive = OneOrMore(IsLetter, "Case Insensitive");
+        var lower = OneOrMore(IsLower, "Lowercase", span => span.ToString());
+        var upper = OneOrMore(IsUpper, "Uppercase", span => span.ToString());
+        var caseInsensitive = OneOrMore(IsLetter, "Case Insensitive", span => span.ToString());
 
         lower.FailsToParse("", "", "Lowercase expected");
         
@@ -302,7 +303,8 @@ class GrammarTests
 
         caseInsensitive.Parses("abcDEF").ShouldBe("abcDEF");
 
-        var even = OneOrMore<int>(x => x % 2 == 0, "even number");
+        var isEven = (int x) => x % 2 == 0;
+        var even = OneOrMore(isEven, "even number", span => span.ToArray());
         var empty = Array.Empty<int>();
         even.FailsToParse(empty, empty, "even number expected");
         even.FailsToParse(new[] { 1, 2, 4, 6 }, new[] { 1, 2, 4, 6 }, "even number expected");
@@ -312,9 +314,9 @@ class GrammarTests
 
     public void ProvidesConveniencePrimitiveRecognizingSequencesOfItemsSatisfyingSomePredicateAFixedNumberOfTimes()
     {
-        var lower2 = Repeat(IsLower, 2, "2 Lowercase");
-        var lower3 = Repeat(IsLower, 3, "3 Lowercase");
-        var lower4 = Repeat(IsLower, 4, "4 Lowercase");
+        var lower2 = Repeat(IsLower, 2, "2 Lowercase", span => span.ToString());
+        var lower3 = Repeat(IsLower, 3, "3 Lowercase", span => span.ToString());
+        var lower4 = Repeat(IsLower, 4, "4 Lowercase", span => span.ToString());
 
         lower2.FailsToParse("", "", "2 Lowercase expected");
         lower3.FailsToParse("", "", "3 Lowercase expected");
@@ -329,9 +331,9 @@ class GrammarTests
         lower4.FailsToParse("abcDEF", "abcDEF", "4 Lowercase expected");
 
 
-        var upper2 = Repeat(IsUpper, 2, "2 Uppercase");
-        var upper3 = Repeat(IsUpper, 3, "3 Uppercase");
-        var upper4 = Repeat(IsUpper, 4, "4 Uppercase");
+        var upper2 = Repeat(IsUpper, 2, "2 Uppercase", span => span.ToString());
+        var upper3 = Repeat(IsUpper, 3, "3 Uppercase", span => span.ToString());
+        var upper4 = Repeat(IsUpper, 4, "4 Uppercase", span => span.ToString());
 
         upper2.FailsToParse("abcDEF", "abcDEF", "2 Uppercase expected");
         upper3.FailsToParse("abcDEF", "abcDEF", "3 Uppercase expected");
@@ -342,9 +344,9 @@ class GrammarTests
         upper4.FailsToParse("DEF", "DEF", "4 Uppercase expected");
 
 
-        var caseInsensitive2 = Repeat(IsLetter, 2, "2 Case Insensitive");
-        var caseInsensitive3 = Repeat(IsLetter, 3, "3 Case Insensitive");
-        var caseInsensitive4 = Repeat(IsLetter, 4, "4 Case Insensitive");
+        var caseInsensitive2 = Repeat(IsLetter, 2, "2 Case Insensitive", span => span.ToString());
+        var caseInsensitive3 = Repeat(IsLetter, 3, "3 Case Insensitive", span => span.ToString());
+        var caseInsensitive4 = Repeat(IsLetter, 4, "4 Case Insensitive", span => span.ToString());
 
         caseInsensitive2.FailsToParse("!abcDEF", "!abcDEF", "2 Case Insensitive expected");
         caseInsensitive3.FailsToParse("!abcDEF", "!abcDEF", "3 Case Insensitive expected");
@@ -354,8 +356,8 @@ class GrammarTests
         caseInsensitive3.PartiallyParses("abcDEF", "DEF").ShouldBe("abc");
         caseInsensitive4.PartiallyParses("abcDEF", "EF").ShouldBe("abcD");
 
-
-        var even = Repeat<int>(x => x % 2 == 0, 2, "2 even numbers");
+        var isEven = (int x) => x % 2 == 0;
+        var even = Repeat(isEven, 2, "2 even numbers", span => span.ToArray());
         var empty = Array.Empty<int>();
         even.FailsToParse(empty, empty, "2 even numbers expected");
         even.FailsToParse(new[] { 1, 2, 4, 6 }, new[] { 1, 2, 4, 6 }, "2 even numbers expected");
@@ -366,23 +368,22 @@ class GrammarTests
         even.Parses(new[] { 2, 4 }).ShouldBe(new[] { 2, 4 });
 
 
-        var attemptRepeat0char = () => Repeat(IsLower, 0, "Lowercase");
+        var attemptRepeat0char = () => Repeat(IsLower, 0, "Lowercase", span => span.ToString());
         attemptRepeat0char
             .ShouldThrow<ArgumentException>()
             .Message.ShouldBe("Repeat requires the given count to be > 1. (Parameter 'count')");
 
-        var attemptRepeat1char = () => Repeat(IsLower, 1, "Lowercase");
+        var attemptRepeat1char = () => Repeat(IsLower, 1, "Lowercase", span => span.ToString());
         attemptRepeat1char
             .ShouldThrow<ArgumentException>()
             .Message.ShouldBe("Repeat requires the given count to be > 1. (Parameter 'count')");
 
-
-        var attemptRepeat0int = () => Repeat<int>(x => x % 2 == 0, 0, "even number");
+        var attemptRepeat0int = () => Repeat(isEven, 0, "even number", span => span.ToArray());
         attemptRepeat0int
             .ShouldThrow<ArgumentException>()
             .Message.ShouldBe("Repeat requires the given count to be > 1. (Parameter 'count')");
 
-        var attemptRepeat1int = () => Repeat<int>(x => x % 2 == 0, 1, "even number");
+        var attemptRepeat1int = () => Repeat(isEven, 1, "even number", span => span.ToArray());
         attemptRepeat1int
             .ShouldThrow<ArgumentException>()
             .Message.ShouldBe("Repeat requires the given count to be > 1. (Parameter 'count')");
@@ -465,7 +466,7 @@ class GrammarTests
                 from metadataAtStart in metadata
                 from a in A
                 from metadataBeforeWhitespace in metadata
-                from whitespace in ZeroOrMore(IsWhiteSpace)
+                from whitespace in ZeroOrMore(IsWhiteSpace, span => span.ToString())
                 from metadataAfterWhitespace in metadata
                 from b in B
                 from metadataAtEnd in metadata

--- a/src/Parsley.Tests/IntegrationTests/Json/Json.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/Json.cs
@@ -92,7 +92,7 @@ public class Json
     {
         get
         {
-            var Digits = OneOrMore(IsDigit, "0..9");
+            var Digits = OneOrMore(IsDigit, "0..9", span => span.ToString());
 
             return
                 from index in Index<char>()
@@ -145,7 +145,7 @@ public class Json
 
             var unicodeEscapeCharacters =
                 from u in Single('u', "unicode escape sequence")
-                from unicodeDigits in Repeat(IsLetterOrDigit, 4, "4 unicode digits")
+                from unicodeDigits in Repeat(IsLetterOrDigit, 4, "4 unicode digits", span => span.ToString())
                 select char.ConvertFromUtf32(
                     int.Parse(
                         unicodeDigits,
@@ -158,7 +158,7 @@ public class Json
                 select unescaped;
 
             var literalCharacters =
-                OneOrMore(c => c != '"' && c != '\\', "non-quote, not-slash character");
+                OneOrMore((char c) => c != '"' && c != '\\', "non-quote, not-slash character", span => span.ToString());
 
             return
                 from index in Index<char>()

--- a/src/Parsley.Tests/IntegrationTests/Json/Json.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/Json.cs
@@ -145,12 +145,13 @@ public class Json
 
             var unicodeEscapeCharacters =
                 from u in Single('u', "unicode escape sequence")
-                from unicodeDigits in Repeat(IsLetterOrDigit, 4, "4 unicode digits", span => span.ToString())
-                select char.ConvertFromUtf32(
-                    int.Parse(
-                        unicodeDigits,
-                        NumberStyles.HexNumber,
-                        CultureInfo.InvariantCulture));
+                from unescaped in Repeat(IsLetterOrDigit, 4, "4 unicode digits",
+                    unicodeDigits => char.ConvertFromUtf32(
+                        int.Parse(
+                            unicodeDigits,
+                            NumberStyles.HexNumber,
+                            CultureInfo.InvariantCulture)))
+                select unescaped;
 
             var charactersFromEscapeSequence =
                 from slash in Single('\\')

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -174,17 +174,7 @@ partial class Grammar
         };
     }
 
-    public static Parser<char, string> Repeat(Func<char, bool> test, int count, string name)
-    {
-        return Repeat(test, count, name, span => span.ToString());
-    }
-
-    public static Parser<TItem, IReadOnlyList<TItem>> Repeat<TItem>(Func<TItem, bool> test, int count, string name)
-    {
-        return Repeat(test, count, name, span => span.ToArray());
-    }
-
-    static Parser<TItem, TValue> Repeat<TItem, TValue>(Func<TItem, bool> test, int count, string name, SpanFunc<TItem, TValue> selector)
+    public static Parser<TItem, TValue> Repeat<TItem, TValue>(Func<TItem, bool> test, int count, string name, SpanFunc<TItem, TValue> selector)
     {
         if (count <= 1)
             throw new ArgumentException(
@@ -210,17 +200,7 @@ partial class Grammar
         };
     }
 
-    public static Parser<char, string> ZeroOrMore(Func<char, bool> test)
-    {
-        return ZeroOrMore(test, span => span.ToString());
-    }
-
-    public static Parser<TItem, IReadOnlyList<TItem>> ZeroOrMore<TItem>(Func<TItem, bool> test)
-    {
-        return ZeroOrMore(test, span => span.ToArray());
-    }
-
-    static Parser<TItem, TValue> ZeroOrMore<TItem, TValue>(Func<TItem, bool> test, SpanFunc<TItem, TValue> selector)
+    public static Parser<TItem, TValue> ZeroOrMore<TItem, TValue>(Func<TItem, bool> test, SpanFunc<TItem, TValue> selector)
     {
         return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
         {
@@ -242,17 +222,7 @@ partial class Grammar
         };
     }
 
-    public static Parser<char, string> OneOrMore(Func<char, bool> test, string name)
-    {
-        return OneOrMore(test, name, span => span.ToString());
-    }
-
-    public static Parser<TItem, IReadOnlyList<TItem>> OneOrMore<TItem>(Func<TItem, bool> test, string name)
-    {
-        return OneOrMore(test, name, span => span.ToArray());
-    }
-
-    static Parser<TItem, TValue> OneOrMore<TItem, TValue>(Func<TItem, bool> test, string name, SpanFunc<TItem, TValue> selector)
+    public static Parser<TItem, TValue> OneOrMore<TItem, TValue>(Func<TItem, bool> test, string name, SpanFunc<TItem, TValue> selector)
     {
         return (ReadOnlySpan<TItem> input, ref int index, out bool succeeded, out string? expectation) =>
         {

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -174,33 +174,6 @@ partial class Grammar
         };
     }
 
-    public static Parser<char, string> ZeroOrMore(Func<char, bool> test)
-    {
-        return ZeroOrMore(test, span => span.ToString());
-    }
-
-    static Parser<char, TValue> ZeroOrMore<TValue>(Func<char, bool> test, SpanFunc<char, TValue> selector)
-    {
-        return (ReadOnlySpan<char> input, ref int index, out bool succeeded, out string? expectation) =>
-        {
-            var length = input.CountWhile(index, test);
-            
-            if (length > 0)
-            {
-                var slice = input.Slice(index, length);
-                index += length;
-
-                expectation = null;
-                succeeded = true;
-                return selector(slice);
-            }
-
-            expectation = null;
-            succeeded = true;
-            return selector(ReadOnlySpan<char>.Empty);
-        };
-    }
-
     public static Parser<char, string> OneOrMore(Func<char, bool> test, string name)
     {
         return OneOrMore(test, name, span => span.ToString());
@@ -264,9 +237,14 @@ partial class Grammar
         };
     }
 
+    public static Parser<char, string> ZeroOrMore(Func<char, bool> test)
+    {
+        return ZeroOrMore(test, span => span.ToString());
+    }
+
     public static Parser<TItem, IReadOnlyList<TItem>> ZeroOrMore<TItem>(Func<TItem, bool> test)
     {
-        return ZeroOrMore<TItem, IReadOnlyList<TItem>>(test, span => span.ToArray());
+        return ZeroOrMore(test, span => span.ToArray());
     }
 
     static Parser<TItem, TValue> ZeroOrMore<TItem, TValue>(Func<TItem, bool> test, SpanFunc<TItem, TValue> selector)

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -233,35 +233,9 @@ partial class Grammar
         return Repeat(test, count, name, span => span.ToString());
     }
 
-    static Parser<char, TValue> Repeat<TValue>(Func<char, bool> test, int count, string name, SpanFunc<char, TValue> selector)
-    {
-        if (count <= 1)
-            throw new ArgumentException(
-                $"{nameof(Repeat)} requires the given count to be > 1.", nameof(count));
-
-        return (ReadOnlySpan<char> input, ref int index, out bool succeeded, out string? expectation) =>
-        {
-            var length = input.CountWhile(index, test, maxCount: count);
-            
-            if (length == count)
-            {
-                var slice = input.Slice(index, length);
-                index += length;
-
-                expectation = null;
-                succeeded = true;
-                return selector(slice);
-            }
-
-            expectation = name;
-            succeeded = false;
-            return default;
-        };
-    }
-
     public static Parser<TItem, IReadOnlyList<TItem>> Repeat<TItem>(Func<TItem, bool> test, int count, string name)
     {
-        return Repeat<TItem, IReadOnlyList<TItem>>(test, count, name, span => span.ToArray());
+        return Repeat(test, count, name, span => span.ToArray());
     }
 
     static Parser<TItem, TValue> Repeat<TItem, TValue>(Func<TItem, bool> test, int count, string name, SpanFunc<TItem, TValue> selector)

--- a/src/Parsley/Grammar.Repetition.cs
+++ b/src/Parsley/Grammar.Repetition.cs
@@ -174,33 +174,6 @@ partial class Grammar
         };
     }
 
-    public static Parser<char, string> OneOrMore(Func<char, bool> test, string name)
-    {
-        return OneOrMore(test, name, span => span.ToString());
-    }
-
-    static Parser<char, TValue> OneOrMore<TValue>(Func<char, bool> test, string name, SpanFunc<char, TValue> selector)
-    {
-        return (ReadOnlySpan<char> input, ref int index, out bool succeeded, out string? expectation) =>
-        {
-            var length = input.CountWhile(index, test);
-
-            if (length > 0)
-            {
-                var slice = input.Slice(index, length);
-                index += length;
-
-                expectation = null;
-                succeeded = true;
-                return selector(slice);
-            }
-
-            expectation = name;
-            succeeded = false;
-            return default;
-        };
-    }
-
     public static Parser<char, string> Repeat(Func<char, bool> test, int count, string name)
     {
         return Repeat(test, count, name, span => span.ToString());
@@ -269,9 +242,14 @@ partial class Grammar
         };
     }
 
+    public static Parser<char, string> OneOrMore(Func<char, bool> test, string name)
+    {
+        return OneOrMore(test, name, span => span.ToString());
+    }
+
     public static Parser<TItem, IReadOnlyList<TItem>> OneOrMore<TItem>(Func<TItem, bool> test, string name)
     {
-        return OneOrMore<TItem, IReadOnlyList<TItem>>(test, name, span => span.ToArray());
+        return OneOrMore(test, name, span => span.ToArray());
     }
 
     static Parser<TItem, TValue> OneOrMore<TItem, TValue>(Func<TItem, bool> test, string name, SpanFunc<TItem, TValue> selector)

--- a/src/Parsley/SpanFunc.cs
+++ b/src/Parsley/SpanFunc.cs
@@ -1,0 +1,3 @@
+namespace Parsley;
+
+public delegate TResult SpanFunc<TItem, out TResult>(ReadOnlySpan<TItem> input);


### PR DESCRIPTION
This improves performance around low-level repetition parsers which recognize a slice of items from the original input span, such as recognizing a contiguous series of digit characters representing an integer.

Before this change, the discovered slice would be realized into an allocated string (if the original input items are `char`), or an allocated array (if the original input items are not `char`). Even if the caller's intention was to then pass these strings/arrays to a span-accepting method for further processing, they would incur the cost of the intermediate allocation.

With this change, the user instead provides a lambda expression which operates directly on the discovered span of matched items, giving them control over whether to allocate via ToString, ToArray, or perform some other transformation such as calling the span-accepting overloads of int.Parse without ever having to 'realize' an intermediate string.

At first this did not seem possible, as the tempting thing would be to offer a parameter of type `Func<ReadOnlySpan<TItem>>, TResult>`, which is a compiler error. `ReadOnlySpan<T>` is a `ref struct`, which can never appear as a generic type parameter. The subtlety is that `ref struct` types cannot *appear as a generic type parameter*, but they **can** *appear as inputs and outputs of custom delegate types* so long as they don't need to appear in the angle brackets in the process. Where `Func` would break the rule for span inputs:

```cs
public delegate TResult Func<in T, out TResult>(T input);
```

Our custom `SpanFunc` satisfies all the rules:

```cs
public delegate TResult SpanFunc<TItem, out TResult>(ReadOnlySpan<TItem> input);
```

# Before

|           Method |     sample |        Mean | Ratio |    Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|----------------- |----------- |------------:|------:|---------:|--------:|--------:|----------:|
| System.Text.Json |  Recursion |   722.74 us |  1.00 |  42.9688 | 41.0156 | 41.0156 |    145 KB |
|  Newtonsoft.Json |  Recursion |   413.05 us |  0.57 |  37.5977 | 12.6953 |       - |    181 KB |
|          **Parsley** |  Recursion |   **630.76 us** |  0.87 |  31.2500 |  0.9766 |       - |    **131 KB** |
|           Pidgin |  Recursion |   551.00 us |  0.76 |  55.6641 |  1.9531 |       - |    229 KB |
|                  |            |             |       |          |         |         |           |
| System.Text.Json | Repetition |   338.95 us |  1.00 |  24.9023 |  5.8594 |       - |    103 KB |
|  Newtonsoft.Json | Repetition | 1,140.12 us |  3.36 | 103.5156 | 50.7813 |       - |    641 KB |
|          **Parsley** | Repetition |   **686.46 us** |  2.03 |  62.5000 | 27.3438 |       - |    **337 KB** |
|           Pidgin | Repetition | 1,897.00 us |  5.60 |  56.6406 | 25.3906 |       - |    311 KB |
|                  |            |             |       |          |         |         |           |
| System.Text.Json |    Typical |    19.02 us |  1.00 |   1.3733 |       - |       - |      6 KB |
|  Newtonsoft.Json |    Typical |    54.64 us |  2.87 |   9.7656 |  1.1597 |       - |     40 KB |
|          **Parsley** |    Typical |    **38.74 us** |  2.04 |   5.7983 |       - |       - |     **24 KB** |
|           Pidgin |    Typical |    96.94 us |  5.10 |   5.0049 |       - |       - |     21 KB |

# After

|           Method |     sample |        Mean | Ratio |    Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|----------------- |----------- |------------:|------:|---------:|--------:|--------:|----------:|
| System.Text.Json |  Recursion |   729.47 us |  1.00 |  42.9688 | 41.0156 | 41.0156 |    145 KB |
|  Newtonsoft.Json |  Recursion |   417.03 us |  0.57 |  37.5977 | 12.6953 |       - |    181 KB |
|          **Parsley** |  Recursion |   **597.92 us** |  0.82 |  31.2500 |  0.9766 |       - |    **131 KB** |
|           Pidgin |  Recursion |   559.35 us |  0.77 |  55.6641 |  1.9531 |       - |    229 KB |
|                  |            |             |       |          |         |         |           |
| System.Text.Json | Repetition |   339.81 us |  1.00 |  24.9023 |  5.8594 |       - |    103 KB |
|  Newtonsoft.Json | Repetition | 1,181.44 us |  3.48 | 103.5156 | 50.7813 |       - |    641 KB |
|          **Parsley** | Repetition |   **680.93 us** |  2.00 |  58.5938 | 28.3203 |       - |    **326 KB** |
|           Pidgin | Repetition | 1,905.68 us |  5.61 |  56.6406 | 25.3906 |       - |    311 KB |
|                  |            |             |       |          |         |         |           |
| System.Text.Json |    Typical |    18.99 us |  1.00 |   1.3733 |       - |       - |      6 KB |
|  Newtonsoft.Json |    Typical |    54.45 us |  2.87 |   9.7656 |  0.8545 |       - |     40 KB |
|          **Parsley** |    Typical |    **38.95 us** |  2.05 |   5.6763 |  0.1221 |       - |     **23 KB** |
|           Pidgin |    Typical |   101.62 us |  5.54 |   5.0049 |       - |       - |     20 KB |

The measureable improvement here is in the Repetition example, where we encountere and parse int values nested within 256 consecutive JSON objects.