### PR TITLE
Update build process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,11 @@ jobs:
         with:
           dotnet-version: |
             6.0
+      - run: dotnet --info
       - name: Build / Test / Pack
+        env:
+          DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: true
+          TERM: xterm
         run: pwsh ./eng/pack.ps1
       - name: Release to MyGet
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: .NET SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.302'
       - name: Build / Test / Pack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
       - name: .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.302'
+          dotnet-version: |
+            6.0
       - name: Build / Test / Pack
         run: pwsh ./eng/pack.ps1
       - name: Release to MyGet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ jobs:
       - name: .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.302'
+          dotnet-version: |
+            6.0
       - name: Build / Test / Pack
         run: pwsh ./eng/pack.ps1
       - name: Release to NuGet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: .NET SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.302'
       - name: Build / Test / Pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,11 @@ jobs:
         with:
           dotnet-version: |
             6.0
+      - run: dotnet --info
       - name: Build / Test / Pack
+        env:
+          DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: true
+          TERM: xterm
         run: pwsh ./eng/pack.ps1
       - name: Release to NuGet
         env:

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot utilities)
 
-exec { dotnet --info }
 exec { dotnet tool restore }
 exec { dotnet clean src -c Release --nologo -v minimal }
 exec { dotnet build src -c Release --nologo }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "6.0.302",
-    "rollForward": "feature"
-  }
-}


### PR DESCRIPTION
1. Remove global.json, so that we no longer pin the dotnet SDK for development-time concerns. This pinning capability is meant to be used only as-needed, and avoiding it is encouraged so that developers can leverage the latest development tools available. The SDK is meant to be backward compatible with older target frameworks. Note that the solution's TargetFramework selections do still strictly dictate versions pertaining to execution-time concerns.
2. Update actions/checkout and actions/setup-dotnet to v3.
3. The GitHub Actions build environment uses the latest patch version of each SDK Major.Minor listed, matching the intended set of TargetFrameworks in the solution.
4. Since `dotnet --info` is generally verbose and usually only useful on the CI/CD logs, perform that as a distinct step over in the CI/CD configuration.