### PR TITLE
Target net8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            7.0
+            8.0
       - run: dotnet --info
       - name: Build / Test / Pack
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            7.0
+            8.0
       - run: dotnet --info
       - name: Build / Test / Pack
         env:

--- a/src/Parsley.Benchmark/Parsley.Benchmark.csproj
+++ b/src/Parsley.Benchmark/Parsley.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/Parsley.Benchmark/Parsley.Benchmark.csproj
+++ b/src/Parsley.Benchmark/Parsley.Benchmark.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pidgin" Version="3.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="Pidgin" Version="3.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Parsley.Tests/IntegrationTests/Json/JsonTests.cs
+++ b/src/Parsley.Tests/IntegrationTests/Json/JsonTests.cs
@@ -80,20 +80,22 @@ class JsonTests
     public void ParsesComplexJsonValuesSkippingOptionalWhitespace()
     {
         const string whitespaceCharacters = "\r\n\t";
-        const string complex = whitespaceCharacters + @"
+        const string complex = $$"""
+            {{whitespaceCharacters}}
 
+            {
+                "numbers" : [ 10, 20, 30 ],
+                "window":
                 {
-                    ""numbers"" : [ 10, 20, 30 ],
-                    ""window"":
-                    {
-                        ""title"": ""Sample Widget""," + whitespaceCharacters + @"
-                        ""parent"": null,
-                        ""maximized"": true  ,
-                        ""transparent"": false
-                    }
+                    "title": "Sample Widget",{{whitespaceCharacters}}
+                    "parent": null,
+                    "maximized": true  ,
+                    "transparent": false
                 }
+            }
 
-            " + whitespaceCharacters;
+            {{whitespaceCharacters}}
+            """;
 
         var value = Parses(complex);
         value.ShouldNotBeNull();
@@ -111,46 +113,53 @@ class JsonTests
     public void ProvidesUsefulErrorMessagesForDeeplyPlacedTokenizerErrors()
     {
         const string whitespaceCharacters = "\r\n\t";
-        const string invalidSlashP = whitespaceCharacters + @"
+        const string invalidSlashP = $$"""
+            {{whitespaceCharacters}}
 
+            {
+                "numbers" : [ 10, 20, 30 ],
+                "window":
                 {
-                    ""numbers"" : [ 10, 20, 30 ],
-                    ""window"":
-                    {
-                        ""title"": ""Sample Widget""," + whitespaceCharacters + @"
-                        ""parent"": null,
-                        ""maximized"": true  ,
-                        ""trans\parent"": false
-                    }
-                }";
+                    "title": "Sample Widget",{{whitespaceCharacters}}
+                    "parent": null,
+                    "maximized": true  ,
+                    "trans\parent": false
+                }
+            }
+            """;
 
         FailsToParse(invalidSlashP,
-            @"parent"": false
-                    }
-                }",
+            """
+            parent": false
+                }
+            }
+            """,
             "escape sequence expected");
     }
 
     public void ProvidesUsefulErrorMessagesForDeeplyPlacedGrammarErrors()
     {
         const string whitespaceCharacters = "\r\n\t";
-        const string invalidSlashP = whitespaceCharacters + @"
+        const string invalidSlashP = $$"""
+            {{whitespaceCharacters}}
 
+            {
+                "numbers" : [ 10, 20, 30 ],
+                "window":
                 {
-                    ""numbers"" : [ 10, 20, 30 ],
-                    ""window"":
-                    {
-                        ""title"": ""Sample Widget""," + whitespaceCharacters + @"
-                        ""parent"": null,
-                        ""maximized"": true  ,
-                        ""transparent"": false 7
-                    }
-                }";
+                    "title": "Sample Widget",{{whitespaceCharacters}}
+                    "parent": null,
+                    "maximized": true  ,
+                    "transparent": false 7
+                }
+            }
+            """;
 
-        FailsToParse(invalidSlashP,
-            @"7
-                    }
-                }",
+        FailsToParse(invalidSlashP,            """
+            7
+                }
+            }
+            """,
             "} expected");
     }
 

--- a/src/Parsley.Tests/Parsley.Tests.csproj
+++ b/src/Parsley.Tests/Parsley.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>

--- a/src/Parsley.Tests/Parsley.Tests.csproj
+++ b/src/Parsley.Tests/Parsley.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Fixie.TestAdapter" Version="3.3.0" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Parsley/Parsley.csproj
+++ b/src/Parsley/Parsley.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>

--- a/src/Parsley/Parsley.csproj
+++ b/src/Parsley/Parsley.csproj
@@ -16,9 +16,11 @@
     <PackageProjectUrl>https://github.com/plioi/parsley</PackageProjectUrl>
     <RepositoryUrl>https://github.com/plioi/parsley</RepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="false" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 

--- a/src/Parsley/Parsley.csproj
+++ b/src/Parsley/Parsley.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="2.5.0">
+    <PackageReference Include="MinVer" Version="4.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This targets net8.0 and C# 12, upgrading all dependencies.

We're not yet taking advantage of collection expressions, since ReSharper doesn't yet support them and mistakes their usage for errors.